### PR TITLE
[utils] Calcite initialization for Modin_on_omnisci mode

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -87,6 +87,9 @@ def import_pandas_into_module_namespace(namespace, mode, ray_tmpdir=None, ray_me
             raise ValueError(f"Unknown pandas mode {mode}")
         import modin.pandas as pd
 
+        # Some components of Modin with OmniSci engine are initialized only
+        # at the moment of query execution, so for proper benchmarks performance
+        # measurement we need to initialize these parts before any measurements
         if mode == "Modin_on_omnisci":
             init_modin_on_omnisci(pd)
     if not isinstance(namespace, (list, tuple)):

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -41,6 +41,14 @@ def convert_type_ibis2pandas(types):
     return types
 
 
+def init_modin_on_omnisci(pd):
+    # Calcite initialization
+    data = {"a": [1, 2, 3]}
+    df = pd.DataFrame(data)
+    df = df + 1
+    _ = df.index
+
+
 def import_pandas_into_module_namespace(namespace, mode, ray_tmpdir=None, ray_memory=None):
     if mode == "Pandas":
         print("Pandas backend: pure Pandas")
@@ -78,6 +86,9 @@ def import_pandas_into_module_namespace(namespace, mode, ray_tmpdir=None, ray_me
         else:
             raise ValueError(f"Unknown pandas mode {mode}")
         import modin.pandas as pd
+
+        if mode == "Modin_on_omnisci":
+            init_modin_on_omnisci(pd)
     if not isinstance(namespace, (list, tuple)):
         namespace = [namespace]
     for space in namespace:


### PR DESCRIPTION
We need to initialize Calcite before benchmarks runs to get correct timing results in `Modin_on_omnisci` mode.