### PR TITLE
Remove hack for mortgage delimiter

### DIFF
--- a/mortgage/mortgage_pandas.py
+++ b/mortgage/mortgage_pandas.py
@@ -120,7 +120,7 @@ class MortgagePandasBenchmark:
             fname,
             dtype=all_but_dates,
             parse_dates=dates_only,
-            delimiter="|" if self._is_remote_dataset else ",",
+            delimiter="|",
             skiprows=1,
             **kw,
         )


### PR DESCRIPTION
With modin-project/modin#2129 merged we don't need this hack anymore for Modin. Not sure if it doesn't break some other targets.