### PR TITLE
[CI] add scripts for Modin_on_omnisci mode

### DIFF
--- a/run_ibis_benchmark.py
+++ b/run_ibis_benchmark.py
@@ -314,19 +314,25 @@ def main():
         "-commit_omnisci",
         dest="commit_omnisci",
         default="1234567890123456789012345678901234567890",
-        help="Omnisci commit hash to use for benchmark.",
+        help="Omnisci commit hash used for benchmark.",
     )
     optional.add_argument(
         "-commit_ibis",
         dest="commit_ibis",
         default="1234567890123456789012345678901234567890",
-        help="Ibis commit hash to use for benchmark.",
+        help="Ibis commit hash used for benchmark.",
     )
     optional.add_argument(
         "-commit_omniscripts",
         dest="commit_omniscripts",
         default="1234567890123456789012345678901234567890",
-        help="Omniscripts commit hash to use for tests.",
+        help="Omniscripts commit hash used for benchmark.",
+    )
+    optional.add_argument(
+        "-commit_modin",
+        dest="commit_modin",
+        default="1234567890123456789012345678901234567890",
+        help="Modin commit hash used for benchmark.",
     )
     optional.add_argument(
         "-debug_mode",
@@ -456,6 +462,7 @@ def main():
                         "OmnisciCommitHash": args.commit_omnisci,
                         "IbisCommitHash": args.commit_ibis,
                         "OmniscriptsCommitHash": args.commit_omniscripts,
+                        "ModinCommitHash": args.commit_modin,
                     }
 
                     reporting_fields_benchmark_etl = {

--- a/run_ibis_tests.py
+++ b/run_ibis_tests.py
@@ -363,19 +363,25 @@ def main():
         "-commit_omnisci",
         dest="commit_omnisci",
         default="1234567890123456789012345678901234567890",
-        help="Omnisci commit hash to use for tests.",
+        help="Omnisci commit hash used for tests.",
     )
     commits.add_argument(
         "-commit_ibis",
         dest="commit_ibis",
         default="1234567890123456789012345678901234567890",
-        help="Ibis commit hash to use for tests.",
+        help="Ibis commit hash used for tests.",
     )
     commits.add_argument(
         "-commit_omniscripts",
         dest="commit_omniscripts",
         default="1234567890123456789012345678901234567890",
-        help="Omniscripts commit hash to use for tests.",
+        help="Omniscripts commit hash used for tests.",
+    )
+    commits.add_argument(
+        "-commit_modin",
+        dest="commit_modin",
+        default="1234567890123456789012345678901234567890",
+        help="Modin commit hash used for tests.",
     )
     optional.add_argument(
         "-debug_mode",
@@ -614,6 +620,7 @@ def main():
                 "commit_omniscripts",
                 "debug_mode",
                 "extended_functionality",
+                "commit_modin",
             ]
             args_dict = vars(args)
             args_dict["data_file"] = f"'{args_dict['data_file']}'"

--- a/run_ibis_tests.py
+++ b/run_ibis_tests.py
@@ -115,7 +115,7 @@ def main():
 
     # Omnisci server parameters
     omnisci.add_argument(
-        "-executable", dest="executable", required=True, help="Path to omnisci_server executable."
+        "-executable", dest="executable", required=False, help="Path to omnisci_server executable."
     )
     omnisci.add_argument(
         "-omnisci_cwd",

--- a/teamcity_build_scripts/14-ny_taxi_pandas_ibis.sh
+++ b/teamcity_build_scripts/14-ny_taxi_pandas_ibis.sh
@@ -20,7 +20,7 @@ python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env Tru
                           -data_file '${DATASETS_PWD}/taxi/trips_xa{a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t}.csv.gz'           \
                           -pandas_mode Pandas -ray_tmpdir /tmp                                                                 \
                           -commit_omnisci ${BUILD_REVISION}                                                                    \
-                          -commit_ibis ${BUILD_IBIS_REVISION}                                                                  \
+                          -commit_modin ${BUILD_MODIN_REVISION}                                                                \
                           -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
                           ${ADDITIONAL_OPTS}                                                                                   \
                           ${DB_COMMON_OPTS} ${DB_TAXI_OPTS}

--- a/teamcity_build_scripts/14-ny_taxi_pandas_ibis.sh
+++ b/teamcity_build_scripts/14-ny_taxi_pandas_ibis.sh
@@ -20,7 +20,7 @@ python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env Tru
                           -data_file '${DATASETS_PWD}/taxi/trips_xa{a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t}.csv.gz'           \
                           -pandas_mode Pandas -ray_tmpdir /tmp                                                                 \
                           -commit_omnisci ${BUILD_REVISION}                                                                    \
-                          -commit_modin ${BUILD_MODIN_REVISION}                                                                \
+                          -commit_ibis ${BUILD_IBIS_REVISION}                                                                  \
                           -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
                           ${ADDITIONAL_OPTS}                                                                                   \
                           ${DB_COMMON_OPTS} ${DB_TAXI_OPTS}

--- a/teamcity_build_scripts/19-build_modin_dbe.sh
+++ b/teamcity_build_scripts/19-build_modin_dbe.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check False --save_env True --python_version 3.7 -task build            \
+                          --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
+                          --ibis_path "$PWD/../ibis/"                                                                          \
+                          -executable "$PWD/../omniscidb/build/bin/omnisci_server"
+                          --modin_path "$PWD/../modin/"

--- a/teamcity_build_scripts/19-build_modin_dbe.sh
+++ b/teamcity_build_scripts/19-build_modin_dbe.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check False --save_env True --python_version 3.7 -task build            \
+python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check False --save_env True -task build                                 \
                           --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
                           -executable "$PWD/../omniscidb/build/bin/omnisci_server"                                             \
                           --modin_path "$PWD/../modin/"

--- a/teamcity_build_scripts/19-build_modin_dbe.sh
+++ b/teamcity_build_scripts/19-build_modin_dbe.sh
@@ -2,5 +2,5 @@
 
 python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check False --save_env True --python_version 3.7 -task build            \
                           --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
-                          -executable "$PWD/../omniscidb/build/bin/omnisci_server"
+                          -executable "$PWD/../omniscidb/build/bin/omnisci_server"                                             \
                           --modin_path "$PWD/../modin/"

--- a/teamcity_build_scripts/19-build_modin_dbe.sh
+++ b/teamcity_build_scripts/19-build_modin_dbe.sh
@@ -2,6 +2,5 @@
 
 python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check False --save_env True --python_version 3.7 -task build            \
                           --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
-                          --ibis_path "$PWD/../ibis/"                                                                          \
                           -executable "$PWD/../omniscidb/build/bin/omnisci_server"
                           --modin_path "$PWD/../modin/"

--- a/teamcity_build_scripts/20-h2o_groupby_small_modin_on_ray.sh
+++ b/teamcity_build_scripts/20-h2o_groupby_small_modin_on_ray.sh
@@ -7,7 +7,7 @@ python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env Tru
                           -pandas_mode Modin_on_ray -ray_tmpdir ${PWD}/tmp                                                     \
                           -commit_omnisci ${BUILD_REVISION}                                                                    \
                           -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
-                          -commit_modin ${BUILD_OMNISCRIPTS_REVISION}
+                          -commit_modin ${BUILD_MODIN_REVISION}                                                                \
                           ${ADDITIONAL_OPTS}                                                                                   \
                           ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
                           ${DB_COMMON_OPTS} ${DB_H2O_OPTS}

--- a/teamcity_build_scripts/20-h2o_groupby_small_modin_on_ray.sh
+++ b/teamcity_build_scripts/20-h2o_groupby_small_modin_on_ray.sh
@@ -3,12 +3,9 @@
 mkdir -p ${PWD}/tmp
 python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True --python_version 3.7 -task benchmark         \
                           --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
-                          --ibis_path "${PWD}/../ibis/"                                                                        \
-                          -executable "${PWD}/../omniscidb/build/bin/omnisci_server"                                           \
-                          -bench_name h2o -data_file '${DATASETS_PWD}/h2o/G1_1e9_1e2_0_0.csv'                                  \
+                          -bench_name h2o -data_file '${DATASETS_PWD}/h2o/G1_1e7_1e2_0_0.csv'                                  \
                           -pandas_mode Modin_on_ray -ray_tmpdir ${PWD}/tmp                                                     \
                           -commit_omnisci ${BUILD_REVISION}                                                                    \
-                          -commit_ibis ${BUILD_IBIS_REVISION}                                                                  \
                           -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
                           ${ADDITIONAL_OPTS}                                                                                   \
                           ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \

--- a/teamcity_build_scripts/20-h2o_groupby_small_modin_on_ray.sh
+++ b/teamcity_build_scripts/20-h2o_groupby_small_modin_on_ray.sh
@@ -7,6 +7,7 @@ python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env Tru
                           -pandas_mode Modin_on_ray -ray_tmpdir ${PWD}/tmp                                                     \
                           -commit_omnisci ${BUILD_REVISION}                                                                    \
                           -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
+                          -commit_modin ${BUILD_OMNISCRIPTS_REVISION}
                           ${ADDITIONAL_OPTS}                                                                                   \
                           ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
                           ${DB_COMMON_OPTS} ${DB_H2O_OPTS}

--- a/teamcity_build_scripts/20-h2o_groupby_small_modin_on_ray.sh
+++ b/teamcity_build_scripts/20-h2o_groupby_small_modin_on_ray.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 mkdir -p ${PWD}/tmp
-python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True --python_version 3.7 -task benchmark         \
+python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True -task benchmark                              \
                           --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
                           -bench_name h2o -data_file '${DATASETS_PWD}/h2o/G1_1e7_1e2_0_0.csv'                                  \
                           -pandas_mode Modin_on_ray -ray_tmpdir ${PWD}/tmp                                                     \

--- a/teamcity_build_scripts/21-h2o_groupby_small_modin_on_omnisci.sh
+++ b/teamcity_build_scripts/21-h2o_groupby_small_modin_on_omnisci.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 mkdir -p ${PWD}/tmp
-python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True --python_version 3.7 -task benchmark         \
+python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True -task benchmark                              \
                           --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
                           -bench_name h2o -data_file '${DATASETS_PWD}/h2o/G1_1e7_1e2_0_0.csv'                                  \
                           -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                 \

--- a/teamcity_build_scripts/21-h2o_groupby_small_modin_on_omnisci.sh
+++ b/teamcity_build_scripts/21-h2o_groupby_small_modin_on_omnisci.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+mkdir -p ${PWD}/tmp
+python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True --python_version 3.7 -task benchmark         \
+                          --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
+                          -bench_name h2o -data_file '${DATASETS_PWD}/h2o/G1_1e7_1e2_0_0.csv'                                  \
+                          -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                 \
+                          -commit_omnisci ${BUILD_REVISION}                                                                    \
+                          -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
+                          ${ADDITIONAL_OPTS}                                                                                   \
+                          ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
+                          ${DB_COMMON_OPTS} ${DB_H2O_OPTS}

--- a/teamcity_build_scripts/21-h2o_groupby_small_modin_on_omnisci.sh
+++ b/teamcity_build_scripts/21-h2o_groupby_small_modin_on_omnisci.sh
@@ -7,6 +7,7 @@ python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env Tru
                           -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                 \
                           -commit_omnisci ${BUILD_REVISION}                                                                    \
                           -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
+                          -commit_modin ${BUILD_MODIN_REVISION}                                                                \
                           ${ADDITIONAL_OPTS}                                                                                   \
                           ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
                           ${DB_COMMON_OPTS} ${DB_H2O_OPTS}

--- a/teamcity_build_scripts/22-h2o_groupby_medium_modin_on_ray.sh
+++ b/teamcity_build_scripts/22-h2o_groupby_medium_modin_on_ray.sh
@@ -3,12 +3,9 @@
 mkdir -p ${PWD}/tmp
 python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True --python_version 3.7 -task benchmark         \
                           --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
-                          --ibis_path "${PWD}/../ibis/"                                                                        \
-                          -executable "${PWD}/../omniscidb/build/bin/omnisci_server"                                           \
-                          -bench_name h2o -data_file '${DATASETS_PWD}/h2o/J1_1e8_NA_0_0.csv'                                   \
+                          -bench_name h2o -data_file '${DATASETS_PWD}/h2o/G1_1e8_1e2_0_0.csv'                                  \
                           -pandas_mode Modin_on_ray -ray_tmpdir ${PWD}/tmp                                                     \
                           -commit_omnisci ${BUILD_REVISION}                                                                    \
-                          -commit_ibis ${BUILD_IBIS_REVISION}                                                                  \
                           -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
                           ${ADDITIONAL_OPTS}                                                                                   \
                           ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \

--- a/teamcity_build_scripts/22-h2o_groupby_medium_modin_on_ray.sh
+++ b/teamcity_build_scripts/22-h2o_groupby_medium_modin_on_ray.sh
@@ -7,6 +7,7 @@ python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env Tru
                           -pandas_mode Modin_on_ray -ray_tmpdir ${PWD}/tmp                                                     \
                           -commit_omnisci ${BUILD_REVISION}                                                                    \
                           -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
+                          -commit_modin ${BUILD_MODIN_REVISION}                                                                \
                           ${ADDITIONAL_OPTS}                                                                                   \
                           ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
                           ${DB_COMMON_OPTS} ${DB_H2O_OPTS}

--- a/teamcity_build_scripts/22-h2o_groupby_medium_modin_on_ray.sh
+++ b/teamcity_build_scripts/22-h2o_groupby_medium_modin_on_ray.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 mkdir -p ${PWD}/tmp
-python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True --python_version 3.7 -task benchmark         \
+python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True -task benchmark                              \
                           --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
                           -bench_name h2o -data_file '${DATASETS_PWD}/h2o/G1_1e8_1e2_0_0.csv'                                  \
                           -pandas_mode Modin_on_ray -ray_tmpdir ${PWD}/tmp                                                     \

--- a/teamcity_build_scripts/23-h2o_groupby_medium_modin_on_omnisci.sh
+++ b/teamcity_build_scripts/23-h2o_groupby_medium_modin_on_omnisci.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+mkdir -p ${PWD}/tmp
+python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True --python_version 3.7 -task benchmark         \
+                          --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
+                          -bench_name h2o -data_file '${DATASETS_PWD}/h2o/G1_1e8_1e2_0_0.csv'                                  \
+                          -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                 \
+                          -commit_omnisci ${BUILD_REVISION}                                                                    \
+                          -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
+                          ${ADDITIONAL_OPTS}                                                                                   \
+                          ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
+                          ${DB_COMMON_OPTS} ${DB_H2O_OPTS}

--- a/teamcity_build_scripts/23-h2o_groupby_medium_modin_on_omnisci.sh
+++ b/teamcity_build_scripts/23-h2o_groupby_medium_modin_on_omnisci.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 mkdir -p ${PWD}/tmp
-python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True --python_version 3.7 -task benchmark         \
+python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True -task benchmark                              \
                           --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
                           -bench_name h2o -data_file '${DATASETS_PWD}/h2o/G1_1e8_1e2_0_0.csv'                                  \
                           -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                 \

--- a/teamcity_build_scripts/23-h2o_groupby_medium_modin_on_omnisci.sh
+++ b/teamcity_build_scripts/23-h2o_groupby_medium_modin_on_omnisci.sh
@@ -7,6 +7,7 @@ python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env Tru
                           -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                 \
                           -commit_omnisci ${BUILD_REVISION}                                                                    \
                           -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
+                          -commit_modin ${BUILD_MODIN_REVISION}                                                                \
                           ${ADDITIONAL_OPTS}                                                                                   \
                           ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
                           ${DB_COMMON_OPTS} ${DB_H2O_OPTS}

--- a/teamcity_build_scripts/24-h2o_groupby_big_modin_on_ray.sh
+++ b/teamcity_build_scripts/24-h2o_groupby_big_modin_on_ray.sh
@@ -7,6 +7,7 @@ python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env Tru
                           -pandas_mode Modin_on_ray -ray_tmpdir ${PWD}/tmp                                                     \
                           -commit_omnisci ${BUILD_REVISION}                                                                    \
                           -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
+                          -commit_modin ${BUILD_MODIN_REVISION}                                                                \
                           ${ADDITIONAL_OPTS}                                                                                   \
                           ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
                           ${DB_COMMON_OPTS} ${DB_H2O_OPTS}

--- a/teamcity_build_scripts/24-h2o_groupby_big_modin_on_ray.sh
+++ b/teamcity_build_scripts/24-h2o_groupby_big_modin_on_ray.sh
@@ -3,12 +3,9 @@
 mkdir -p ${PWD}/tmp
 python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True --python_version 3.7 -task benchmark         \
                           --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
-                          --ibis_path "${PWD}/../ibis/"                                                                        \
-                          -executable "${PWD}/../omniscidb/build/bin/omnisci_server"                                           \
-                          -bench_name h2o -data_file '${DATASETS_PWD}/h2o/J1_1e7_NA_0_0.csv'                                   \
+                          -bench_name h2o -data_file '${DATASETS_PWD}/h2o/G1_1e9_1e2_0_0.csv'                                  \
                           -pandas_mode Modin_on_ray -ray_tmpdir ${PWD}/tmp                                                     \
                           -commit_omnisci ${BUILD_REVISION}                                                                    \
-                          -commit_ibis ${BUILD_IBIS_REVISION}                                                                  \
                           -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
                           ${ADDITIONAL_OPTS}                                                                                   \
                           ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \

--- a/teamcity_build_scripts/24-h2o_groupby_big_modin_on_ray.sh
+++ b/teamcity_build_scripts/24-h2o_groupby_big_modin_on_ray.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 mkdir -p ${PWD}/tmp
-python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True --python_version 3.7 -task benchmark         \
+python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True -task benchmark                              \
                           --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
                           -bench_name h2o -data_file '${DATASETS_PWD}/h2o/G1_1e9_1e2_0_0.csv'                                  \
                           -pandas_mode Modin_on_ray -ray_tmpdir ${PWD}/tmp                                                     \

--- a/teamcity_build_scripts/25-h2o_groupby_big_modin_on_omnisci.sh
+++ b/teamcity_build_scripts/25-h2o_groupby_big_modin_on_omnisci.sh
@@ -3,12 +3,9 @@
 mkdir -p ${PWD}/tmp
 python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True --python_version 3.7 -task benchmark         \
                           --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
-                          --ibis_path "${PWD}/../ibis/"                                                                        \
-                          -executable "${PWD}/../omniscidb/build/bin/omnisci_server"                                           \
-                          -bench_name h2o -data_file '${DATASETS_PWD}/h2o/G1_1e8_1e2_0_0.csv'                                  \
-                          -pandas_mode Modin_on_ray -ray_tmpdir ${PWD}/tmp                                                     \
+                          -bench_name h2o -data_file '${DATASETS_PWD}/h2o/G1_1e9_1e2_0_0.csv'                                  \
+                          -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                     \
                           -commit_omnisci ${BUILD_REVISION}                                                                    \
-                          -commit_ibis ${BUILD_IBIS_REVISION}                                                                  \
                           -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
                           ${ADDITIONAL_OPTS}                                                                                   \
                           ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \

--- a/teamcity_build_scripts/25-h2o_groupby_big_modin_on_omnisci.sh
+++ b/teamcity_build_scripts/25-h2o_groupby_big_modin_on_omnisci.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 mkdir -p ${PWD}/tmp
-python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True --python_version 3.7 -task benchmark         \
+python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True -task benchmark                              \
                           --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
                           -bench_name h2o -data_file '${DATASETS_PWD}/h2o/G1_1e9_1e2_0_0.csv'                                  \
                           -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                 \

--- a/teamcity_build_scripts/25-h2o_groupby_big_modin_on_omnisci.sh
+++ b/teamcity_build_scripts/25-h2o_groupby_big_modin_on_omnisci.sh
@@ -7,6 +7,7 @@ python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env Tru
                           -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                 \
                           -commit_omnisci ${BUILD_REVISION}                                                                    \
                           -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
+                          -commit_modin ${BUILD_MODIN_REVISION}                                                                \
                           ${ADDITIONAL_OPTS}                                                                                   \
                           ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
                           ${DB_COMMON_OPTS} ${DB_H2O_OPTS}

--- a/teamcity_build_scripts/26-h2o_join_small_modin_on_ray.sh
+++ b/teamcity_build_scripts/26-h2o_join_small_modin_on_ray.sh
@@ -7,6 +7,7 @@ python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env Tru
                           -pandas_mode Modin_on_ray -ray_tmpdir ${PWD}/tmp                                                     \
                           -commit_omnisci ${BUILD_REVISION}                                                                    \
                           -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
+                          -commit_modin ${BUILD_MODIN_REVISION}                                                                \
                           ${ADDITIONAL_OPTS}                                                                                   \
                           ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
                           ${DB_COMMON_OPTS} ${DB_H2O_OPTS}

--- a/teamcity_build_scripts/26-h2o_join_small_modin_on_ray.sh
+++ b/teamcity_build_scripts/26-h2o_join_small_modin_on_ray.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+mkdir -p ${PWD}/tmp
+python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True --python_version 3.7 -task benchmark         \
+                          --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
+                          -bench_name h2o -data_file '${DATASETS_PWD}/h2o/J1_1e7_NA_0_0.csv'                                   \
+                          -pandas_mode Modin_on_ray -ray_tmpdir ${PWD}/tmp                                                     \
+                          -commit_omnisci ${BUILD_REVISION}                                                                    \
+                          -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
+                          ${ADDITIONAL_OPTS}                                                                                   \
+                          ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
+                          ${DB_COMMON_OPTS} ${DB_H2O_OPTS}

--- a/teamcity_build_scripts/26-h2o_join_small_modin_on_ray.sh
+++ b/teamcity_build_scripts/26-h2o_join_small_modin_on_ray.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 mkdir -p ${PWD}/tmp
-python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True --python_version 3.7 -task benchmark         \
+python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True -task benchmark                              \
                           --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
                           -bench_name h2o -data_file '${DATASETS_PWD}/h2o/J1_1e7_NA_0_0.csv'                                   \
                           -pandas_mode Modin_on_ray -ray_tmpdir ${PWD}/tmp                                                     \

--- a/teamcity_build_scripts/27-h2o_join_small_modin_on_omnisci.sh
+++ b/teamcity_build_scripts/27-h2o_join_small_modin_on_omnisci.sh
@@ -3,12 +3,9 @@
 mkdir -p ${PWD}/tmp
 python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True --python_version 3.7 -task benchmark         \
                           --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
-                          --ibis_path "${PWD}/../ibis/"                                                                        \
-                          -executable "${PWD}/../omniscidb/build/bin/omnisci_server"                                           \
-                          -bench_name h2o -data_file '${DATASETS_PWD}/h2o/G1_1e7_1e2_0_0.csv'                                  \
-                          -pandas_mode Modin_on_ray -ray_tmpdir ${PWD}/tmp                                                     \
+                          -bench_name h2o -data_file '${DATASETS_PWD}/h2o/J1_1e7_NA_0_0.csv'                                   \
+                          -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                     \
                           -commit_omnisci ${BUILD_REVISION}                                                                    \
-                          -commit_ibis ${BUILD_IBIS_REVISION}                                                                  \
                           -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
                           ${ADDITIONAL_OPTS}                                                                                   \
                           ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \

--- a/teamcity_build_scripts/27-h2o_join_small_modin_on_omnisci.sh
+++ b/teamcity_build_scripts/27-h2o_join_small_modin_on_omnisci.sh
@@ -7,6 +7,7 @@ python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env Tru
                           -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                 \
                           -commit_omnisci ${BUILD_REVISION}                                                                    \
                           -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
+                          -commit_modin ${BUILD_MODIN_REVISION}                                                                \
                           ${ADDITIONAL_OPTS}                                                                                   \
                           ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
                           ${DB_COMMON_OPTS} ${DB_H2O_OPTS}

--- a/teamcity_build_scripts/27-h2o_join_small_modin_on_omnisci.sh
+++ b/teamcity_build_scripts/27-h2o_join_small_modin_on_omnisci.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 mkdir -p ${PWD}/tmp
-python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True --python_version 3.7 -task benchmark         \
+python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True -task benchmark                              \
                           --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
                           -bench_name h2o -data_file '${DATASETS_PWD}/h2o/J1_1e7_NA_0_0.csv'                                   \
                           -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                 \

--- a/teamcity_build_scripts/27-h2o_join_small_modin_on_omnisci.sh
+++ b/teamcity_build_scripts/27-h2o_join_small_modin_on_omnisci.sh
@@ -4,7 +4,7 @@ mkdir -p ${PWD}/tmp
 python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True --python_version 3.7 -task benchmark         \
                           --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
                           -bench_name h2o -data_file '${DATASETS_PWD}/h2o/J1_1e7_NA_0_0.csv'                                   \
-                          -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                     \
+                          -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                 \
                           -commit_omnisci ${BUILD_REVISION}                                                                    \
                           -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
                           ${ADDITIONAL_OPTS}                                                                                   \

--- a/teamcity_build_scripts/28-h2o_join_medium_modin_on_ray.sh
+++ b/teamcity_build_scripts/28-h2o_join_medium_modin_on_ray.sh
@@ -7,6 +7,7 @@ python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env Tru
                           -pandas_mode Modin_on_ray -ray_tmpdir ${PWD}/tmp                                                     \
                           -commit_omnisci ${BUILD_REVISION}                                                                    \
                           -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
+                          -commit_modin ${BUILD_MODIN_REVISION}                                                                \
                           ${ADDITIONAL_OPTS}                                                                                   \
                           ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
                           ${DB_COMMON_OPTS} ${DB_H2O_OPTS}

--- a/teamcity_build_scripts/28-h2o_join_medium_modin_on_ray.sh
+++ b/teamcity_build_scripts/28-h2o_join_medium_modin_on_ray.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 mkdir -p ${PWD}/tmp
-python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True --python_version 3.7 -task benchmark         \
+python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True -task benchmark                              \
                           --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
                           -bench_name h2o -data_file '${DATASETS_PWD}/h2o/J1_1e8_NA_0_0.csv'                                   \
                           -pandas_mode Modin_on_ray -ray_tmpdir ${PWD}/tmp                                                     \

--- a/teamcity_build_scripts/28-h2o_join_medium_modin_on_ray.sh
+++ b/teamcity_build_scripts/28-h2o_join_medium_modin_on_ray.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+mkdir -p ${PWD}/tmp
+python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True --python_version 3.7 -task benchmark         \
+                          --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
+                          -bench_name h2o -data_file '${DATASETS_PWD}/h2o/J1_1e8_NA_0_0.csv'                                   \
+                          -pandas_mode Modin_on_ray -ray_tmpdir ${PWD}/tmp                                                     \
+                          -commit_omnisci ${BUILD_REVISION}                                                                    \
+                          -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
+                          ${ADDITIONAL_OPTS}                                                                                   \
+                          ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
+                          ${DB_COMMON_OPTS} ${DB_H2O_OPTS}

--- a/teamcity_build_scripts/29-h2o_join_medium_modin_on_omnisci.sh
+++ b/teamcity_build_scripts/29-h2o_join_medium_modin_on_omnisci.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+mkdir -p ${PWD}/tmp
+python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True --python_version 3.7 -task benchmark         \
+                          --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
+                          -bench_name h2o -data_file '${DATASETS_PWD}/h2o/J1_1e8_NA_0_0.csv'                                   \
+                          -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                     \
+                          -commit_omnisci ${BUILD_REVISION}                                                                    \
+                          -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
+                          ${ADDITIONAL_OPTS}                                                                                   \
+                          ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
+                          ${DB_COMMON_OPTS} ${DB_H2O_OPTS}

--- a/teamcity_build_scripts/29-h2o_join_medium_modin_on_omnisci.sh
+++ b/teamcity_build_scripts/29-h2o_join_medium_modin_on_omnisci.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 mkdir -p ${PWD}/tmp
-python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True --python_version 3.7 -task benchmark         \
+python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True -task benchmark                              \
                           --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
                           -bench_name h2o -data_file '${DATASETS_PWD}/h2o/J1_1e8_NA_0_0.csv'                                   \
                           -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                 \

--- a/teamcity_build_scripts/29-h2o_join_medium_modin_on_omnisci.sh
+++ b/teamcity_build_scripts/29-h2o_join_medium_modin_on_omnisci.sh
@@ -7,6 +7,7 @@ python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env Tru
                           -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                 \
                           -commit_omnisci ${BUILD_REVISION}                                                                    \
                           -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
+                          -commit_modin ${BUILD_MODIN_REVISION}                                                                \
                           ${ADDITIONAL_OPTS}                                                                                   \
                           ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
                           ${DB_COMMON_OPTS} ${DB_H2O_OPTS}

--- a/teamcity_build_scripts/29-h2o_join_medium_modin_on_omnisci.sh
+++ b/teamcity_build_scripts/29-h2o_join_medium_modin_on_omnisci.sh
@@ -4,7 +4,7 @@ mkdir -p ${PWD}/tmp
 python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True --python_version 3.7 -task benchmark         \
                           --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
                           -bench_name h2o -data_file '${DATASETS_PWD}/h2o/J1_1e8_NA_0_0.csv'                                   \
-                          -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                     \
+                          -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                 \
                           -commit_omnisci ${BUILD_REVISION}                                                                    \
                           -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
                           ${ADDITIONAL_OPTS}                                                                                   \

--- a/teamcity_build_scripts/30-census_modin_on_omnisci.sh
+++ b/teamcity_build_scripts/30-census_modin_on_omnisci.sh
@@ -9,6 +9,7 @@ python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env Tru
                           -pandas_mode Modin_on_omnisci -ray_tmpdir /tmp                                                       \
                           -commit_omnisci ${BUILD_REVISION}                                                                    \
                           -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
+                          -commit_modin ${BUILD_MODIN_REVISION}                                                                \
                           ${ADDITIONAL_OPTS}                                                                                   \
                           ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
                           ${DB_COMMON_OPTS} ${DB_CENSUS_OPTS}

--- a/teamcity_build_scripts/30-census_modin_on_omnisci.sh
+++ b/teamcity_build_scripts/30-census_modin_on_omnisci.sh
@@ -2,11 +2,9 @@
 
 mkdir -p ${PWD}/tmp
 python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True --python_version 3.7 -task benchmark         \
-                          --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
-                          -executable "${PWD}/../omniscidb/build/bin/omnisci_server"                                           \
-                          -table census -bench_name census -dfiles_num 1 -iterations 1                                         \
+                          --ci_requirements "${PWD}/ci_requirements.yml" -bench_name census                                    \
                           -data_file '${DATASETS_PWD}/census/ipums_education2income_1970-2010.csv.gz'                          \
-                          -pandas_mode Modin_on_omnisci -ray_tmpdir /tmp                                                       \
+                          -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                 \
                           -commit_omnisci ${BUILD_REVISION}                                                                    \
                           -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
                           -commit_modin ${BUILD_MODIN_REVISION}                                                                \

--- a/teamcity_build_scripts/30-census_modin_on_omnisci.sh
+++ b/teamcity_build_scripts/30-census_modin_on_omnisci.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+mkdir -p ${PWD}/tmp
 python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True --python_version 3.7 -task benchmark         \
                           --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
                           -executable "${PWD}/../omniscidb/build/bin/omnisci_server"                                           \

--- a/teamcity_build_scripts/30-census_modin_on_omnisci.sh
+++ b/teamcity_build_scripts/30-census_modin_on_omnisci.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True --python_version 3.7 -task benchmark         \
+                          --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
+                          -executable "${PWD}/../omniscidb/build/bin/omnisci_server"                                           \
+                          -table census -bench_name census -dfiles_num 1 -iterations 1                                         \
+                          -data_file '${DATASETS_PWD}/census/ipums_education2income_1970-2010.csv.gz'                          \
+                          -pandas_mode Modin_on_omnisci -ray_tmpdir /tmp                                                       \
+                          -commit_omnisci ${BUILD_REVISION}                                                                    \
+                          -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
+                          ${ADDITIONAL_OPTS}                                                                                   \
+                          ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
+                          ${DB_COMMON_OPTS} ${DB_CENSUS_OPTS}

--- a/teamcity_build_scripts/30-census_modin_on_omnisci.sh
+++ b/teamcity_build_scripts/30-census_modin_on_omnisci.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 mkdir -p ${PWD}/tmp
-python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True --python_version 3.7 -task benchmark         \
+python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True -task benchmark                              \
                           --ci_requirements "${PWD}/ci_requirements.yml" -bench_name census                                    \
                           -data_file '${DATASETS_PWD}/census/ipums_education2income_1970-2010.csv.gz'                          \
                           -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                 \

--- a/teamcity_build_scripts/31-census_modin_on_ray.sh
+++ b/teamcity_build_scripts/31-census_modin_on_ray.sh
@@ -2,11 +2,9 @@
 
 mkdir -p ${PWD}/tmp
 python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True --python_version 3.7 -task benchmark         \
-                          --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
-                          -executable "${PWD}/../omniscidb/build/bin/omnisci_server"                                           \
-                          -table census -bench_name census -dfiles_num 1 -iterations 1                                         \
+                          --ci_requirements "${PWD}/ci_requirements.yml" -bench_name census                                    \
                           -data_file '${DATASETS_PWD}/census/ipums_education2income_1970-2010.csv.gz'                          \
-                          -pandas_mode Modin_on_ray -ray_tmpdir /tmp                                                           \
+                          -pandas_mode Modin_on_ray -ray_tmpdir ${PWD}/tmp                                                     \
                           -commit_omnisci ${BUILD_REVISION}                                                                    \
                           -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
                           -commit_modin ${BUILD_MODIN_REVISION}                                                                \

--- a/teamcity_build_scripts/31-census_modin_on_ray.sh
+++ b/teamcity_build_scripts/31-census_modin_on_ray.sh
@@ -9,6 +9,7 @@ python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env Tru
                           -pandas_mode Modin_on_ray -ray_tmpdir /tmp                                                           \
                           -commit_omnisci ${BUILD_REVISION}                                                                    \
                           -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
+                          -commit_modin ${BUILD_MODIN_REVISION}                                                                \
                           ${ADDITIONAL_OPTS}                                                                                   \
                           ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
                           ${DB_COMMON_OPTS} ${DB_CENSUS_OPTS}

--- a/teamcity_build_scripts/31-census_modin_on_ray.sh
+++ b/teamcity_build_scripts/31-census_modin_on_ray.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 mkdir -p ${PWD}/tmp
-python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True --python_version 3.7 -task benchmark         \
+python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True -task benchmark                              \
                           --ci_requirements "${PWD}/ci_requirements.yml" -bench_name census                                    \
                           -data_file '${DATASETS_PWD}/census/ipums_education2income_1970-2010.csv.gz'                          \
                           -pandas_mode Modin_on_ray -ray_tmpdir ${PWD}/tmp                                                     \

--- a/teamcity_build_scripts/31-census_modin_on_ray.sh
+++ b/teamcity_build_scripts/31-census_modin_on_ray.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+mkdir -p ${PWD}/tmp
 python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True --python_version 3.7 -task benchmark         \
                           --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
                           -executable "${PWD}/../omniscidb/build/bin/omnisci_server"                                           \

--- a/teamcity_build_scripts/31-census_modin_on_ray.sh
+++ b/teamcity_build_scripts/31-census_modin_on_ray.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True --python_version 3.7 -task benchmark         \
+                          --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
+                          -executable "${PWD}/../omniscidb/build/bin/omnisci_server"                                           \
+                          -table census -bench_name census -dfiles_num 1 -iterations 1                                         \
+                          -data_file '${DATASETS_PWD}/census/ipums_education2income_1970-2010.csv.gz'                          \
+                          -pandas_mode Modin_on_ray -ray_tmpdir /tmp                                                           \
+                          -commit_omnisci ${BUILD_REVISION}                                                                    \
+                          -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
+                          ${ADDITIONAL_OPTS}                                                                                   \
+                          ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
+                          ${DB_COMMON_OPTS} ${DB_CENSUS_OPTS}

--- a/teamcity_build_scripts/32-ny_taxi_modin_on_ray_20M_records.sh
+++ b/teamcity_build_scripts/32-ny_taxi_modin_on_ray_20M_records.sh
@@ -8,5 +8,6 @@ python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env Tru
                           -dfiles_num 1 -pandas_mode Modin_on_ray -ray_tmpdir ${PWD}/tmp                                       \
                           -commit_omnisci ${BUILD_REVISION}                                                                    \
                           -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
+                          -commit_modin ${BUILD_MODIN_REVISION}                                                                \
                           ${ADDITIONAL_OPTS}                                                                                   \
                           ${DB_COMMON_OPTS} ${DB_TAXI_OPTS}

--- a/teamcity_build_scripts/32-ny_taxi_modin_on_ray_20M_records.sh
+++ b/teamcity_build_scripts/32-ny_taxi_modin_on_ray_20M_records.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
 mkdir -p ${PWD}/tmp
-python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True --python_version 3.7 -task benchmark         \
-                          --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
-                          -bench_name ny_taxi -iterations 1                                                                    \
+python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True -task benchmark                              \
+                          --ci_requirements "${PWD}/ci_requirements.yml" -bench_name ny_taxi                                   \
                           -data_file '${DATASETS_PWD}/taxi/trips_xa{a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t}.csv'              \
                           -dfiles_num 1 -pandas_mode Modin_on_ray -ray_tmpdir ${PWD}/tmp                                       \
                           -commit_omnisci ${BUILD_REVISION}                                                                    \

--- a/teamcity_build_scripts/32-ny_taxi_modin_on_ray_20M_records.sh
+++ b/teamcity_build_scripts/32-ny_taxi_modin_on_ray_20M_records.sh
@@ -3,10 +3,10 @@
 mkdir -p ${PWD}/tmp
 python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True --python_version 3.7 -task benchmark         \
                           --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
-                          -bench_name h2o -data_file '${DATASETS_PWD}/h2o/G1_1e9_1e2_0_0.csv'                                  \
-                          -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                 \
+                          -bench_name ny_taxi -iterations 1                                                                    \
+                          -data_file '${DATASETS_PWD}/taxi/trips_xa{a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t}.csv'              \
+                          -dfiles_num 1 -pandas_mode Modin_on_ray -ray_tmpdir ${PWD}/tmp                                       \
                           -commit_omnisci ${BUILD_REVISION}                                                                    \
                           -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
                           ${ADDITIONAL_OPTS}                                                                                   \
-                          ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
-                          ${DB_COMMON_OPTS} ${DB_H2O_OPTS}
+                          ${DB_COMMON_OPTS} ${DB_TAXI_OPTS}

--- a/teamcity_build_scripts/33-ny_taxi_modin_on_omnisci_20M_records.sh
+++ b/teamcity_build_scripts/33-ny_taxi_modin_on_omnisci_20M_records.sh
@@ -8,5 +8,6 @@ python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env Tru
                           -dfiles_num 1 -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                   \
                           -commit_omnisci ${BUILD_REVISION}                                                                    \
                           -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
+                          -commit_modin ${BUILD_MODIN_REVISION}                                                                \
                           ${ADDITIONAL_OPTS}                                                                                   \
                           ${DB_COMMON_OPTS} ${DB_TAXI_OPTS}

--- a/teamcity_build_scripts/33-ny_taxi_modin_on_omnisci_20M_records.sh
+++ b/teamcity_build_scripts/33-ny_taxi_modin_on_omnisci_20M_records.sh
@@ -3,10 +3,10 @@
 mkdir -p ${PWD}/tmp
 python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True --python_version 3.7 -task benchmark         \
                           --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
-                          -bench_name h2o -data_file '${DATASETS_PWD}/h2o/G1_1e9_1e2_0_0.csv'                                  \
-                          -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                 \
+                          -bench_name ny_taxi -iterations 1                                                                    \
+                          -data_file '${DATASETS_PWD}/taxi/trips_xa{a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t}.csv'              \
+                          -dfiles_num 1 -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                   \
                           -commit_omnisci ${BUILD_REVISION}                                                                    \
                           -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
                           ${ADDITIONAL_OPTS}                                                                                   \
-                          ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
-                          ${DB_COMMON_OPTS} ${DB_H2O_OPTS}
+                          ${DB_COMMON_OPTS} ${DB_TAXI_OPTS}

--- a/teamcity_build_scripts/33-ny_taxi_modin_on_omnisci_20M_records.sh
+++ b/teamcity_build_scripts/33-ny_taxi_modin_on_omnisci_20M_records.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
 mkdir -p ${PWD}/tmp
-python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True --python_version 3.7 -task benchmark         \
-                          --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
-                          -bench_name ny_taxi -iterations 1                                                                    \
+python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True -task benchmark                              \
+                          --ci_requirements "${PWD}/ci_requirements.yml" -bench_name ny_taxi                                   \
                           -data_file '${DATASETS_PWD}/taxi/trips_xa{a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t}.csv'              \
                           -dfiles_num 1 -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                   \
                           -commit_omnisci ${BUILD_REVISION}                                                                    \


### PR DESCRIPTION
In order to create performance CI to compare benchmarks results in `Modin_on_omnisci` vs `Modin_on_ray` modes we need next changes:
1) Additional TeamCity scripts in these two modes should be added (for now covered H2O, Census and NYC taxi benchmarks).
2) Modin commit hash also should be added since modin changes can affect benchmark performance.
3) There is no need to mark `executable` flag as required - when `task` flag is set to only `benchmark`, `executable` can be omitted.