### PR TITLE
install modin dependencies via conda

### DIFF
--- a/run_ibis_tests.py
+++ b/run_ibis_tests.py
@@ -445,11 +445,16 @@ def main():
                 conda_env.run(["pip", "install", "--upgrade", "protobuf"], print_output=False)
 
             if args.modin_path:
-                install_modin_reqs_cmdline = ["pip", "install", "-e", ".[all]"]
+                install_modin_reqs_cmdline = [
+                    "conda",
+                    "env",
+                    "update",
+                    "--name",
+                    f"{args.env_name}",
+                    "--file",
+                    "environment.yml",
+                ]
                 if args.modin_pkgs_dir:
-                    # If your home directory is space limited, you can be unable to install all Modin
-                    # dependencies in home directory, so using of --target flag can solve this problem
-                    install_modin_reqs_cmdline += ["--target", args.modin_pkgs_dir]
                     os.environ["PYTHONPATH"] = (
                         os.getenv("PYTHONPATH") + os.pathsep + args.modin_pkgs_dir
                         if os.getenv("PYTHONPATH")


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

This PR resolve also next problem.

```python
   from .session import get_session, AioSession
  File "/miniconda3/envs/test-env/lib/python3.7/site-packages/aiobotocore/session.py", line 1, in <module>
    from botocore.session import Session, EVENT_ALIASES, ServiceModel, UnknownServiceError
ImportError: cannot import name 'EVENT_ALIASES' from 'botocore.session' (/miniconda3/envs/test-env/lib/python3.7/site-packages/botocore/session.py)
```

Package `botocore` is a dependency of package `s3fs`, which was installed via the conda (as a `omniscripts` dependency), and also installed via pip (as a `modin` dependency), because of this, the incompatibility indicated above appeared.
