### PR TITLE
[Plasticc] correct sklearn import

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -381,9 +381,9 @@ class SklearnImport:
             self.current_optimizer = optimizer
 
             if optimizer == "intel":
-                import daal4py
+                import daal4py.sklearn as sklearn
 
-                daal4py.sklearn.patch_sklearn()
+                sklearn.patch_sklearn()
                 from sklearn.model_selection import train_test_split
             elif optimizer == "stock":
                 from sklearn.model_selection import train_test_split


### PR DESCRIPTION
Plasticc ML portion fails without this change because `import daal4py` doesn't import `sklearn` (in Census `sklearn` imported in the benchmark runner https://github.com/intel-ai/omniscripts/blob/master/census/census_pandas_ibis.py#L276).