### PR TITLE
[Mortgage] use original dataset for etl_pandas

### DIFF
--- a/mortgage/mortgage_pandas.py
+++ b/mortgage/mortgage_pandas.py
@@ -120,7 +120,7 @@ class MortgagePandasBenchmark:
             fname,
             dtype=all_but_dates,
             parse_dates=dates_only,
-            delimiter="|",
+            delimiter="|" if self._is_remote_dataset else ",",
             skiprows=1,
             **kw,
         )

--- a/mortgage/mortgage_pandas.py
+++ b/mortgage/mortgage_pandas.py
@@ -24,12 +24,6 @@ class MortgagePandasBenchmark:
         leave_category_strings=False,
         pandas_mode="Pandas",
     ):
-        # datasets_pwd = (
-        #     os.path.dirname(os.path.dirname(mortgage_path))
-        #     if mortgage_path.endswith("/")
-        #     else os.path.dirname(mortgage_path)
-        # )
-        # mortgage_path = os.path.join(datasets_pwd, "mortgage")
         # some hack - do not append things if mortgage_path is a URL
         self._is_remote_dataset = "://" in mortgage_path
         self.acq_data_path = mortgage_path + ("/acq" if not self._is_remote_dataset else "")

--- a/mortgage/mortgage_pandas.py
+++ b/mortgage/mortgage_pandas.py
@@ -24,6 +24,12 @@ class MortgagePandasBenchmark:
         leave_category_strings=False,
         pandas_mode="Pandas",
     ):
+        datasets_pwd = (
+            os.path.dirname(os.path.dirname(mortgage_path))
+            if mortgage_path.endswith("/")
+            else os.path.dirname(mortgage_path)
+        )
+        mortgage_path = os.path.join(datasets_pwd, "mortgage")
         # some hack - do not append things if mortgage_path is a URL
         self._is_remote_dataset = "://" in mortgage_path
         self.acq_data_path = mortgage_path + ("/acq" if not self._is_remote_dataset else "")

--- a/mortgage/mortgage_pandas.py
+++ b/mortgage/mortgage_pandas.py
@@ -24,12 +24,12 @@ class MortgagePandasBenchmark:
         leave_category_strings=False,
         pandas_mode="Pandas",
     ):
-        datasets_pwd = (
-            os.path.dirname(os.path.dirname(mortgage_path))
-            if mortgage_path.endswith("/")
-            else os.path.dirname(mortgage_path)
-        )
-        mortgage_path = os.path.join(datasets_pwd, "mortgage")
+        # datasets_pwd = (
+        #     os.path.dirname(os.path.dirname(mortgage_path))
+        #     if mortgage_path.endswith("/")
+        #     else os.path.dirname(mortgage_path)
+        # )
+        # mortgage_path = os.path.join(datasets_pwd, "mortgage")
         # some hack - do not append things if mortgage_path is a URL
         self._is_remote_dataset = "://" in mortgage_path
         self.acq_data_path = mortgage_path + ("/acq" if not self._is_remote_dataset else "")
@@ -462,6 +462,14 @@ def etl_pandas(
     leave_category_strings=False,
     pandas_mode="Pandas",
 ):
+    # For Pandas version of etl queries used original dataset
+    # without any data format transformation
+    datasets_pwd = (
+        os.path.dirname(os.path.dirname(dataset_path))
+        if dataset_path.endswith("/")
+        else os.path.dirname(dataset_path)
+    )
+    dataset_path = os.path.join(datasets_pwd, "mortgage")
     etl_times = {key: 0.0 for key in etl_keys}
 
     mb = MortgagePandasBenchmark(

--- a/mortgage/mortgage_pandas.py
+++ b/mortgage/mortgage_pandas.py
@@ -120,7 +120,7 @@ class MortgagePandasBenchmark:
             fname,
             dtype=all_but_dates,
             parse_dates=dates_only,
-            delimiter="|" if self._is_remote_dataset else ",",
+            delimiter="|",
             skiprows=1,
             **kw,
         )

--- a/teamcity_build_scripts/18-mortgage.sh
+++ b/teamcity_build_scripts/18-mortgage.sh
@@ -7,7 +7,7 @@ python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env Tru
                           -database_name ${DATABASE_NAME} -table mg_bench_t -bench_name mortgage -dfiles_num 1 -iterations 1  \
                           -ipc_conn True -columnar_output True -lazy_fetch False -multifrag_rs True                           \
                           -fragments_size 2000000 2000000 -import_mode fsi -omnisci_run_kwargs enable-union=1                 \
-                          -data_file '${DATASETS_PWD}/mortgage_new'                                                           \
+                          -data_file '${DATASETS_PWD}/mortgage'                                                               \
                           -pandas_mode Pandas                                                                                 \
                           -optimizer intel -gpu_memory 16                                                                     \
                           -commit_omnisci ${BUILD_REVISION}                                                                   \

--- a/teamcity_build_scripts/18-mortgage.sh
+++ b/teamcity_build_scripts/18-mortgage.sh
@@ -7,7 +7,7 @@ python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env Tru
                           -database_name ${DATABASE_NAME} -table mg_bench_t -bench_name mortgage -dfiles_num 1 -iterations 1  \
                           -ipc_conn True -columnar_output True -lazy_fetch False -multifrag_rs True                           \
                           -fragments_size 2000000 2000000 -import_mode fsi -omnisci_run_kwargs enable-union=1                 \
-                          -data_file '${DATASETS_PWD}/mortgage'                                                               \
+                          -data_file '${DATASETS_PWD}/mortgage_new'                                                           \
                           -pandas_mode Pandas                                                                                 \
                           -optimizer intel -gpu_memory 16                                                                     \
                           -commit_omnisci ${BUILD_REVISION}                                                                   \


### PR DESCRIPTION
Currently Mortgage etl_pandas fails with message for both Modin and Pandas
` ValueError: invalid literal for int() with base 10: '100007365142,R,JPMORGAN CHASE BANK_ NA,8,75000,360,1999-12-01,2000-02-01,79,,1,62,763,N,R,SF,1,P,PA,173,,FRM,,,N,200001'`
In order to fix it, we should pass original Mortgage dataset for etl_pandas (with #161 merged etl_pandas should use dataset with `|` delimiter).