### PR TITLE
Don't sort in plasticc groupby

### DIFF
--- a/plasticc/plasticc_pandas_ibis.py
+++ b/plasticc/plasticc_pandas_ibis.py
@@ -129,7 +129,7 @@ def etl_cpu_pandas(df, df_meta, etl_times):
         "flux_ratio_sq": ["sum"],
         "flux_by_flux_ratio_sq": ["sum"],
     }
-    agg_df = df.groupby("object_id").agg(aggs)
+    agg_df = df.groupby("object_id", sort=False).agg(aggs)
 
     agg_df.columns = ravel_column_names(agg_df.columns)
 


### PR DESCRIPTION
I propose to remove sort from the Modin version of PlastiCC. We don't have this sort in the Ibis version and it works fine. Removing it from the Modin version would allow us to compare Ibis and Modin ETL time.