### PR TITLE
[CI] pin arrow to 1.0 version

### DIFF
--- a/ci_requirements.yml
+++ b/ci_requirements.yml
@@ -18,6 +18,6 @@ dependencies:
   - black=19.10b0
   - flake8
   - Cython
-  - pyarrow<0.17
-  - arrow-cpp<0.17
+  - pyarrow==1.0
+  - arrow-cpp==1.0
   - cmake>=3.15


### PR DESCRIPTION
`arrow` and `arrow-cpp` should be pinned to newer versions to avoid problems with dependencies solving during installing of Modin packages (modin was updated to `arrow==1.0`).