### PR TITLE
[CI] Avoid using `conda run` command for Modin_on_omnisci engine in TeamCity scripts

### DIFF
--- a/teamcity_build_scripts/21-h2o_groupby_small_modin_on_omnisci.sh
+++ b/teamcity_build_scripts/21-h2o_groupby_small_modin_on_omnisci.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
+source ${CONDA_PREFIX}/bin/activate
+conda activate ${ENV_NAME}
 mkdir -p ${PWD}/tmp
-python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True -task benchmark                              \
-                          --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
-                          -bench_name h2o -data_file '${DATASETS_PWD}/h2o/G1_1e7_1e2_0_0.csv'                                  \
-                          -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                 \
-                          -commit_omnisci ${BUILD_REVISION}                                                                    \
-                          -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
-                          -commit_modin ${BUILD_MODIN_REVISION}                                                                \
-                          ${ADDITIONAL_OPTS}                                                                                   \
-                          ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
-                          ${DB_COMMON_OPTS} ${DB_H2O_OPTS}
+python3 run_ibis_benchmark.py -bench_name h2o -data_file '${DATASETS_PWD}/h2o/G1_1e7_1e2_0_0.csv'                                  \
+                              -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                 \
+                              -commit_omnisci ${BUILD_REVISION}                                                                    \
+                              -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
+                              -commit_modin ${BUILD_MODIN_REVISION}                                                                \
+                              ${ADDITIONAL_OPTS}                                                                                   \
+                              ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
+                              ${DB_COMMON_OPTS} ${DB_H2O_OPTS}
+
+conda deactivate

--- a/teamcity_build_scripts/23-h2o_groupby_medium_modin_on_omnisci.sh
+++ b/teamcity_build_scripts/23-h2o_groupby_medium_modin_on_omnisci.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
+source ${CONDA_PREFIX}/bin/activate
+conda activate ${ENV_NAME}
 mkdir -p ${PWD}/tmp
-python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True -task benchmark                              \
-                          --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
-                          -bench_name h2o -data_file '${DATASETS_PWD}/h2o/G1_1e8_1e2_0_0.csv'                                  \
-                          -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                 \
-                          -commit_omnisci ${BUILD_REVISION}                                                                    \
-                          -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
-                          -commit_modin ${BUILD_MODIN_REVISION}                                                                \
-                          ${ADDITIONAL_OPTS}                                                                                   \
-                          ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
-                          ${DB_COMMON_OPTS} ${DB_H2O_OPTS}
+python3 run_ibis_benchmark.py -bench_name h2o -data_file '${DATASETS_PWD}/h2o/G1_1e8_1e2_0_0.csv'                                  \
+                              -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                 \
+                              -commit_omnisci ${BUILD_REVISION}                                                                    \
+                              -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
+                              -commit_modin ${BUILD_MODIN_REVISION}                                                                \
+                              ${ADDITIONAL_OPTS}                                                                                   \
+                              ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
+                              ${DB_COMMON_OPTS} ${DB_H2O_OPTS}
+
+conda deactivate

--- a/teamcity_build_scripts/25-h2o_groupby_big_modin_on_omnisci.sh
+++ b/teamcity_build_scripts/25-h2o_groupby_big_modin_on_omnisci.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
+source ${CONDA_PREFIX}/bin/activate
+conda activate ${ENV_NAME}
 mkdir -p ${PWD}/tmp
-python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True -task benchmark                              \
-                          --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
-                          -bench_name h2o -data_file '${DATASETS_PWD}/h2o/G1_1e9_1e2_0_0.csv'                                  \
-                          -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                 \
-                          -commit_omnisci ${BUILD_REVISION}                                                                    \
-                          -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
-                          -commit_modin ${BUILD_MODIN_REVISION}                                                                \
-                          ${ADDITIONAL_OPTS}                                                                                   \
-                          ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
-                          ${DB_COMMON_OPTS} ${DB_H2O_OPTS}
+python3 run_ibis_benchmark.py -bench_name h2o -data_file '${DATASETS_PWD}/h2o/G1_1e9_1e2_0_0.csv'                                  \
+                              -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                 \
+                              -commit_omnisci ${BUILD_REVISION}                                                                    \
+                              -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
+                              -commit_modin ${BUILD_MODIN_REVISION}                                                                \
+                              ${ADDITIONAL_OPTS}                                                                                   \
+                              ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
+                              ${DB_COMMON_OPTS} ${DB_H2O_OPTS}
+
+conda deactivate

--- a/teamcity_build_scripts/27-h2o_join_small_modin_on_omnisci.sh
+++ b/teamcity_build_scripts/27-h2o_join_small_modin_on_omnisci.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
+source ${CONDA_PREFIX}/bin/activate
+conda activate ${ENV_NAME}
 mkdir -p ${PWD}/tmp
-python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True -task benchmark                              \
-                          --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
-                          -bench_name h2o -data_file '${DATASETS_PWD}/h2o/J1_1e7_NA_0_0.csv'                                   \
-                          -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                 \
-                          -commit_omnisci ${BUILD_REVISION}                                                                    \
-                          -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
-                          -commit_modin ${BUILD_MODIN_REVISION}                                                                \
-                          ${ADDITIONAL_OPTS}                                                                                   \
-                          ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
-                          ${DB_COMMON_OPTS} ${DB_H2O_OPTS}
+python3 run_ibis_benchmark.py -bench_name h2o -data_file '${DATASETS_PWD}/h2o/J1_1e7_NA_0_0.csv'                                   \
+                              -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                 \
+                              -commit_omnisci ${BUILD_REVISION}                                                                    \
+                              -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
+                              -commit_modin ${BUILD_MODIN_REVISION}                                                                \
+                              ${ADDITIONAL_OPTS}                                                                                   \
+                              ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
+                              ${DB_COMMON_OPTS} ${DB_H2O_OPTS}
+
+conda deactivate

--- a/teamcity_build_scripts/29-h2o_join_medium_modin_on_omnisci.sh
+++ b/teamcity_build_scripts/29-h2o_join_medium_modin_on_omnisci.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
+source ${CONDA_PREFIX}/bin/activate
+conda activate ${ENV_NAME}
 mkdir -p ${PWD}/tmp
-python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True -task benchmark                              \
-                          --ci_requirements "${PWD}/ci_requirements.yml"                                                       \
-                          -bench_name h2o -data_file '${DATASETS_PWD}/h2o/J1_1e8_NA_0_0.csv'                                   \
-                          -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                 \
-                          -commit_omnisci ${BUILD_REVISION}                                                                    \
-                          -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
-                          -commit_modin ${BUILD_MODIN_REVISION}                                                                \
-                          ${ADDITIONAL_OPTS}                                                                                   \
-                          ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
-                          ${DB_COMMON_OPTS} ${DB_H2O_OPTS}
+python3 run_ibis_benchmark.py -bench_name h2o -data_file '${DATASETS_PWD}/h2o/J1_1e8_NA_0_0.csv'                                  \
+                              -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                 \
+                              -commit_omnisci ${BUILD_REVISION}                                                                    \
+                              -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
+                              -commit_modin ${BUILD_MODIN_REVISION}                                                                \
+                              ${ADDITIONAL_OPTS}                                                                                   \
+                              ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
+                              ${DB_COMMON_OPTS} ${DB_H2O_OPTS}
+
+conda deactivate

--- a/teamcity_build_scripts/30-census_modin_on_omnisci.sh
+++ b/teamcity_build_scripts/30-census_modin_on_omnisci.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
+source ${CONDA_PREFIX}/bin/activate
+conda activate ${ENV_NAME}
 mkdir -p ${PWD}/tmp
-python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True -task benchmark                              \
-                          --ci_requirements "${PWD}/ci_requirements.yml" -bench_name census                                    \
-                          -data_file '${DATASETS_PWD}/census/ipums_education2income_1970-2010.csv.gz'                          \
-                          -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                 \
-                          -commit_omnisci ${BUILD_REVISION}                                                                    \
-                          -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
-                          -commit_modin ${BUILD_MODIN_REVISION}                                                                \
-                          ${ADDITIONAL_OPTS}                                                                                   \
-                          ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
-                          ${DB_COMMON_OPTS} ${DB_CENSUS_OPTS}
+python3 run_ibis_benchmark.py -bench_name census -data_file '${DATASETS_PWD}/census/ipums_education2income_1970-2010.csv.gz'       \
+                              -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                 \
+                              -commit_omnisci ${BUILD_REVISION}                                                                    \
+                              -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
+                              -commit_modin ${BUILD_MODIN_REVISION}                                                                \
+                              ${ADDITIONAL_OPTS}                                                                                   \
+                              ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
+                              ${DB_COMMON_OPTS} ${DB_H2O_OPTS}
+
+conda deactivate

--- a/teamcity_build_scripts/33-ny_taxi_modin_on_omnisci_20M_records.sh
+++ b/teamcity_build_scripts/33-ny_taxi_modin_on_omnisci_20M_records.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
 
+source ${CONDA_PREFIX}/bin/activate
+conda activate ${ENV_NAME}
 mkdir -p ${PWD}/tmp
-python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True -task benchmark                              \
-                          --ci_requirements "${PWD}/ci_requirements.yml" -bench_name ny_taxi                                   \
-                          -data_file '${DATASETS_PWD}/taxi/trips_xa{a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t}.csv'              \
-                          -dfiles_num 1 -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                   \
-                          -commit_omnisci ${BUILD_REVISION}                                                                    \
-                          -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
-                          -commit_modin ${BUILD_MODIN_REVISION}                                                                \
-                          ${ADDITIONAL_OPTS}                                                                                   \
-                          ${DB_COMMON_OPTS} ${DB_TAXI_OPTS}
+python3 run_ibis_benchmark.py -bench_name ny_taxi                                                                                  \
+                              -data_file '${DATASETS_PWD}/taxi/trips_xa{a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t}.csv'              \
+                              -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                 \
+                              -commit_omnisci ${BUILD_REVISION}                                                                    \
+                              -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
+                              -commit_modin ${BUILD_MODIN_REVISION}                                                                \
+                              ${ADDITIONAL_OPTS}                                                                                   \
+                              ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
+                              ${DB_COMMON_OPTS} ${DB_H2O_OPTS}
+
+conda deactivate

--- a/teamcity_build_scripts/34-plasticc_modin_on_omnisci.sh
+++ b/teamcity_build_scripts/34-plasticc_modin_on_omnisci.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
+source ${CONDA_PREFIX}/bin/activate
+conda activate ${ENV_NAME}
 mkdir -p ${PWD}/tmp
-python3 run_ibis_tests.py --env_name ${ENV_NAME} --env_check True --save_env True -task benchmark                              \
-                          --ci_requirements "${PWD}/ci_requirements.yml" -bench_name plasticc                                  \
-                          -data_file '${DATASETS_PWD}/plasticc/'                                                               \
-                          -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                 \
-                          -commit_omnisci ${BUILD_REVISION}                                                                    \
-                          -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
-                          -commit_modin ${BUILD_MODIN_REVISION}                                                                \
-                          ${ADDITIONAL_OPTS}                                                                                   \
-                          ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
-                          ${DB_COMMON_OPTS} ${DB_PLASTICC_OPTS}
+python3 run_ibis_benchmark.py -bench_name plasticc -data_file '${DATASETS_PWD}/plasticc/'                                          \
+                              -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                 \
+                              -commit_omnisci ${BUILD_REVISION}                                                                    \
+                              -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
+                              -commit_modin ${BUILD_MODIN_REVISION}                                                                \
+                              ${ADDITIONAL_OPTS}                                                                                   \
+                              ${ADDITIONAL_OPTS_NIGHTLY}                                                                           \
+                              ${DB_COMMON_OPTS} ${DB_H2O_OPTS}
+
+conda deactivate


### PR DESCRIPTION
Signed-off-by: Alexander Myskov <alexander.myskov@intel.com>

It was found that benchmarks execution halted if it was ran using `run_ibis_tests.py` script (script uses `conda run` to run `run_ibis_benchmark.py`). Reproducer:
```
# works fine if run command `python reproducer_omnisci.py` from modin_test
# conda env (conda env with modin/omniscripts dependencies and built modin)
# fails if run command `conda run -n modin_test python reproducer_omnisci.py`
# from `base` conda env
import os

os.environ["MODIN_ENGINE"] = "ray"
os.environ["MODIN_BACKEND"] = "omnisci"
os.environ["MODIN_EXPERIMENTAL"] = "True"

import modin.pandas as pd

def init_modin_on_omnisci(pd):
    data = {"a": [1, 2, 3]}
    df = pd.DataFrame(data)
    df = df + 1
    _ = df.index
    
init_modin_on_omnisci(pd)
```