### PR TITLE
[CI] `conda run` workaround fix

### DIFF
--- a/h2o/h2o_modin.py
+++ b/h2o/h2o_modin.py
@@ -5,7 +5,6 @@ import traceback
 import warnings
 from timeit import default_timer as timer
 import gc
-import os
 
 from utils import (
     import_pandas_into_module_namespace,
@@ -437,7 +436,7 @@ def join_query5_modin(x, ys, queries_results, extended_functionality):
 
 
 def queries_modin(filename, pandas_mode, extended_functionality):
-    data_files_names = files_names_from_pattern(os.path.expandvars(filename))
+    data_files_names = files_names_from_pattern(filename)
     data_for_groupby_queries = []
     data_for_join_queries = []
     for f in data_files_names:

--- a/run_ibis_benchmark.py
+++ b/run_ibis_benchmark.py
@@ -427,7 +427,10 @@ def main():
                 parameters["omnisci_server_worker"] = omnisci_server_worker
                 parameters["ipc_connection"] = args.ipc_conn
                 omnisci_server.launch()
-
+            parameters = {
+                key: os.path.expandvars(value) if isinstance(value, str) else value
+                for key, value in parameters.items()
+            }
             benchmark_results = run_benchmark(parameters)
 
             if launch_omnisci_server:

--- a/teamcity_build_scripts/33-ny_taxi_modin_on_omnisci_20M_records.sh
+++ b/teamcity_build_scripts/33-ny_taxi_modin_on_omnisci_20M_records.sh
@@ -5,7 +5,7 @@ conda activate ${ENV_NAME}
 mkdir -p ${PWD}/tmp
 python3 run_ibis_benchmark.py -bench_name ny_taxi                                                                                  \
                               -data_file '${DATASETS_PWD}/taxi/trips_xa{a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t}.csv'              \
-                              -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                                 \
+                              -dfiles_num 1 -pandas_mode Modin_on_omnisci -ray_tmpdir ${PWD}/tmp                                   \
                               -commit_omnisci ${BUILD_REVISION}                                                                    \
                               -commit_omniscripts ${BUILD_OMNISCRIPTS_REVISION}                                                    \
                               -commit_modin ${BUILD_MODIN_REVISION}                                                                \


### PR DESCRIPTION
Signed-off-by: Alexander Myskov <alexander.myskov@intel.com>

We need slightly modify TeamCity NYX taxi benchmark script and `run_ibis_benchmark.py` for proper CI work with "`conda run` workaround" mentioned in https://github.com/intel-ai/omniscripts/pull/179.