### PR TITLE
[CI] remove sys.exit calls

### DIFF
--- a/census/census_pandas_ibis.py
+++ b/census/census_pandas_ibis.py
@@ -330,6 +330,7 @@ def ml(X, y, random_state, n_runs, test_size, optimizer, ml_keys, ml_score_keys)
 
 
 def run_benchmark(parameters):
+    raise Exception
     check_support(parameters, unsupported_params=["dfiles_num", "gpu_memory"])
 
     parameters["data_file"] = parameters["data_file"].replace("'", "")

--- a/census/census_pandas_ibis.py
+++ b/census/census_pandas_ibis.py
@@ -278,8 +278,9 @@ def ml(X, y, random_state, n_runs, test_size, optimizer, ml_keys, ml_score_keys)
         print("Stock sklearn is used")
         import sklearn.linear_model as lm
     else:
-        print(f"Intel optimized and stock sklearn are supported. {optimizer} can't be recognized")
-        sys.exit(1)
+        raise NotImplementedError(
+            f"{optimizer} is not implemented, accessible optimizers are 'stcok' and 'intel'"
+        )
 
     clf = lm.Ridge()
 
@@ -543,4 +544,4 @@ def run_benchmark(parameters):
         return {"ETL": [etl_times_ibis, etl_times], "ML": [ml_times_ibis, ml_times]}
     except Exception:
         traceback.print_exc(file=sys.stdout)
-        sys.exit(1)
+        raise

--- a/census/census_pandas_ibis.py
+++ b/census/census_pandas_ibis.py
@@ -328,7 +328,6 @@ def ml(X, y, random_state, n_runs, test_size, optimizer, ml_keys, ml_score_keys)
 
 
 def run_benchmark(parameters):
-    raise Exception
     check_support(parameters, unsupported_params=["dfiles_num", "gpu_memory"])
 
     parameters["data_file"] = parameters["data_file"].replace("'", "")

--- a/census/census_pandas_ibis.py
+++ b/census/census_pandas_ibis.py
@@ -1,6 +1,4 @@
 # coding: utf-8
-import sys
-import traceback
 import os
 import numpy as np
 from sklearn import config_context
@@ -441,108 +439,102 @@ def run_benchmark(parameters):
 
     ml_score_keys = ["mse_mean", "cod_mean", "mse_dev", "cod_dev"]
 
-    try:
-        if not parameters["no_pandas"]:
-            import_pandas_into_module_namespace(
-                namespace=run_benchmark.__globals__,
-                mode=parameters["pandas_mode"],
-                ray_tmpdir=parameters["ray_tmpdir"],
-                ray_memory=parameters["ray_memory"],
+    if not parameters["no_pandas"]:
+        import_pandas_into_module_namespace(
+            namespace=run_benchmark.__globals__,
+            mode=parameters["pandas_mode"],
+            ray_tmpdir=parameters["ray_tmpdir"],
+            ray_memory=parameters["ray_memory"],
+        )
+
+    etl_times_ibis = None
+    ml_times_ibis = None
+    etl_times = None
+    ml_times = None
+
+    if parameters["validation"] and parameters["import_mode"] != "pandas":
+        print(
+            f"WARNING: validation can not be performed, it works only for 'pandas' \
+                import mode, '{parameters['import_mode']}' passed"
+        )
+
+    if parameters["data_file"].endswith(".csv"):
+        csv_size = getsize(parameters["data_file"])
+    else:
+        print("WARNING: uncompressed datafile not found, default value for dataset_size is set")
+        # deafault csv_size value (unit - MB) obtained by calling getsize
+        # function on the ipums_education2income_1970-2010.csv file
+        # (default Census benchmark data file)
+        csv_size = 2100.0
+
+    if not parameters["no_ibis"]:
+        df_ibis, X_ibis, y_ibis, etl_times_ibis = etl_ibis(
+            filename=parameters["data_file"],
+            columns_names=columns_names,
+            columns_types=columns_types,
+            database_name=parameters["database_name"],
+            table_name=parameters["table"],
+            omnisci_server_worker=parameters["omnisci_server_worker"],
+            delete_old_database=not parameters["dnd"],
+            create_new_table=not parameters["dni"],
+            ipc_connection=parameters["ipc_connection"],
+            validation=parameters["validation"],
+            etl_keys=etl_keys,
+            import_mode=parameters["import_mode"],
+            fragments_size=parameters["fragments_size"],
+        )
+
+        print_results(results=etl_times_ibis, backend="Ibis", unit="s")
+        etl_times_ibis["Backend"] = "Ibis"
+        etl_times_ibis["dataset_size"] = csv_size
+
+        if not parameters["no_ml"]:
+            ml_scores_ibis, ml_times_ibis = ml(
+                X=X_ibis,
+                y=y_ibis,
+                random_state=RANDOM_STATE,
+                n_runs=N_RUNS,
+                test_size=TEST_SIZE,
+                optimizer=parameters["optimizer"],
+                ml_keys=ml_keys,
+                ml_score_keys=ml_score_keys,
             )
+            print_results(results=ml_times_ibis, backend="Ibis", unit="s")
+            ml_times_ibis["Backend"] = "Ibis"
+            print_results(results=ml_scores_ibis, backend="Ibis")
+            ml_scores_ibis["Backend"] = "Ibis"
 
-        etl_times_ibis = None
-        ml_times_ibis = None
-        etl_times = None
-        ml_times = None
+    if not parameters["no_pandas"]:
+        df, X, y, etl_times = etl_pandas(
+            parameters["data_file"],
+            columns_names=columns_names,
+            columns_types=columns_types,
+            etl_keys=etl_keys,
+            pandas_mode=parameters["pandas_mode"],
+        )
 
-        if parameters["validation"] and parameters["import_mode"] != "pandas":
-            print(
-                f"WARNING: validation can not be performed, it works only for 'pandas' \
-                    import mode, '{parameters['import_mode']}' passed"
+        print_results(results=etl_times, backend=parameters["pandas_mode"], unit="s")
+        etl_times["Backend"] = parameters["pandas_mode"]
+        etl_times["dataset_size"] = csv_size
+
+        if not parameters["no_ml"]:
+            ml_scores, ml_times = ml(
+                X=X,
+                y=y,
+                random_state=RANDOM_STATE,
+                n_runs=N_RUNS,
+                test_size=TEST_SIZE,
+                optimizer=parameters["optimizer"],
+                ml_keys=ml_keys,
+                ml_score_keys=ml_score_keys,
             )
+            print_results(results=ml_times, backend=parameters["pandas_mode"], unit="s")
+            ml_times["Backend"] = parameters["pandas_mode"]
+            print_results(results=ml_scores, backend=parameters["pandas_mode"])
+            ml_scores["Backend"] = parameters["pandas_mode"]
 
-        if parameters["data_file"].endswith(".csv"):
-            csv_size = getsize(parameters["data_file"])
-        else:
-            print(
-                "WARNING: uncompressed datafile not found, default value for dataset_size is set"
-            )
-            # deafault csv_size value (unit - MB) obtained by calling getsize
-            # function on the ipums_education2income_1970-2010.csv file
-            # (default Census benchmark data file)
-            csv_size = 2100.0
+    if parameters["validation"] and parameters["import_mode"] == "pandas":
+        # this should work only for pandas mode
+        compare_dataframes(ibis_dfs=(X_ibis, y_ibis), pandas_dfs=(X, y))
 
-        if not parameters["no_ibis"]:
-            df_ibis, X_ibis, y_ibis, etl_times_ibis = etl_ibis(
-                filename=parameters["data_file"],
-                columns_names=columns_names,
-                columns_types=columns_types,
-                database_name=parameters["database_name"],
-                table_name=parameters["table"],
-                omnisci_server_worker=parameters["omnisci_server_worker"],
-                delete_old_database=not parameters["dnd"],
-                create_new_table=not parameters["dni"],
-                ipc_connection=parameters["ipc_connection"],
-                validation=parameters["validation"],
-                etl_keys=etl_keys,
-                import_mode=parameters["import_mode"],
-                fragments_size=parameters["fragments_size"],
-            )
-
-            print_results(results=etl_times_ibis, backend="Ibis", unit="s")
-            etl_times_ibis["Backend"] = "Ibis"
-            etl_times_ibis["dataset_size"] = csv_size
-
-            if not parameters["no_ml"]:
-                ml_scores_ibis, ml_times_ibis = ml(
-                    X=X_ibis,
-                    y=y_ibis,
-                    random_state=RANDOM_STATE,
-                    n_runs=N_RUNS,
-                    test_size=TEST_SIZE,
-                    optimizer=parameters["optimizer"],
-                    ml_keys=ml_keys,
-                    ml_score_keys=ml_score_keys,
-                )
-                print_results(results=ml_times_ibis, backend="Ibis", unit="s")
-                ml_times_ibis["Backend"] = "Ibis"
-                print_results(results=ml_scores_ibis, backend="Ibis")
-                ml_scores_ibis["Backend"] = "Ibis"
-
-        if not parameters["no_pandas"]:
-            df, X, y, etl_times = etl_pandas(
-                parameters["data_file"],
-                columns_names=columns_names,
-                columns_types=columns_types,
-                etl_keys=etl_keys,
-                pandas_mode=parameters["pandas_mode"],
-            )
-
-            print_results(results=etl_times, backend=parameters["pandas_mode"], unit="s")
-            etl_times["Backend"] = parameters["pandas_mode"]
-            etl_times["dataset_size"] = csv_size
-
-            if not parameters["no_ml"]:
-                ml_scores, ml_times = ml(
-                    X=X,
-                    y=y,
-                    random_state=RANDOM_STATE,
-                    n_runs=N_RUNS,
-                    test_size=TEST_SIZE,
-                    optimizer=parameters["optimizer"],
-                    ml_keys=ml_keys,
-                    ml_score_keys=ml_score_keys,
-                )
-                print_results(results=ml_times, backend=parameters["pandas_mode"], unit="s")
-                ml_times["Backend"] = parameters["pandas_mode"]
-                print_results(results=ml_scores, backend=parameters["pandas_mode"])
-                ml_scores["Backend"] = parameters["pandas_mode"]
-
-        if parameters["validation"] and parameters["import_mode"] == "pandas":
-            # this should work only for pandas mode
-            compare_dataframes(ibis_dfs=(X_ibis, y_ibis), pandas_dfs=(X, y))
-
-        return {"ETL": [etl_times_ibis, etl_times], "ML": [ml_times_ibis, ml_times]}
-    except Exception:
-        traceback.print_exc(file=sys.stdout)
-        raise
+    return {"ETL": [etl_times_ibis, etl_times], "ML": [ml_times_ibis, ml_times]}

--- a/environment/environment.py
+++ b/environment/environment.py
@@ -1,12 +1,11 @@
 import re
 import subprocess
-import sys
 from utils_base_env import execute_process
 
 try:
     from conda.cli.python_api import Commands, run_command
 except ImportError:
-    sys.exit("Please run the script from (base) conda environment")
+    raise ImportError("Please run the script from (base) conda environment")
 
 
 class CondaEnvironment:

--- a/h2o/h2o_modin.py
+++ b/h2o/h2o_modin.py
@@ -1,7 +1,5 @@
 # coding: utf-8
 # This script is ported to omniscripts repository from https://github.com/h2oai/db-benchmark
-import sys
-import traceback
 import warnings
 from timeit import default_timer as timer
 import gc
@@ -579,22 +577,18 @@ def run_benchmark(parameters):
 
     parameters["data_file"] = parameters["data_file"].replace("'", "")
 
-    try:
-        raise Exception
-        if not parameters["no_pandas"]:
-            import_pandas_into_module_namespace(
-                namespace=run_benchmark.__globals__,
-                mode=parameters["pandas_mode"],
-                ray_tmpdir=parameters["ray_tmpdir"],
-                ray_memory=parameters["ray_memory"],
-            )
-            queries_results = queries_modin(
-                filename=parameters["data_file"],
-                pandas_mode=parameters["pandas_mode"],
-                extended_functionality=parameters["extended_functionality"],
-            )
+    raise Exception
+    if not parameters["no_pandas"]:
+        import_pandas_into_module_namespace(
+            namespace=run_benchmark.__globals__,
+            mode=parameters["pandas_mode"],
+            ray_tmpdir=parameters["ray_tmpdir"],
+            ray_memory=parameters["ray_memory"],
+        )
+        queries_results = queries_modin(
+            filename=parameters["data_file"],
+            pandas_mode=parameters["pandas_mode"],
+            extended_functionality=parameters["extended_functionality"],
+        )
 
-        return {"ETL": [queries_results], "ML": []}
-    except Exception:
-        traceback.print_exc(file=sys.stdout)
-        raise
+    return {"ETL": [queries_results], "ML": []}

--- a/h2o/h2o_modin.py
+++ b/h2o/h2o_modin.py
@@ -577,7 +577,6 @@ def run_benchmark(parameters):
 
     parameters["data_file"] = parameters["data_file"].replace("'", "")
 
-    raise Exception
     if not parameters["no_pandas"]:
         import_pandas_into_module_namespace(
             namespace=run_benchmark.__globals__,

--- a/h2o/h2o_modin.py
+++ b/h2o/h2o_modin.py
@@ -596,4 +596,4 @@ def run_benchmark(parameters):
         return {"ETL": [queries_results], "ML": []}
     except Exception:
         traceback.print_exc(file=sys.stdout)
-        sys.exit(1)
+        raise

--- a/h2o/h2o_modin.py
+++ b/h2o/h2o_modin.py
@@ -580,6 +580,7 @@ def run_benchmark(parameters):
     parameters["data_file"] = parameters["data_file"].replace("'", "")
 
     try:
+        raise Exception
         if not parameters["no_pandas"]:
             import_pandas_into_module_namespace(
                 namespace=run_benchmark.__globals__,

--- a/mortgage/mortgage.py
+++ b/mortgage/mortgage.py
@@ -705,8 +705,7 @@ parser.add_argument(
 args = parser.parse_args()
 
 if args.df <= 0:
-    print("Bad number of data files specified", args.df)
-    sys.exit(1)
+    raise ValueError("Bad number of data files specified", args.df)
 
 if args.iterations < 1:
     print("Bad number of iterations specified", args.t)

--- a/mortgage/mortgage_runner.py
+++ b/mortgage/mortgage_runner.py
@@ -62,6 +62,7 @@ def _run_ml(df, n_runs, mb, ml_keys, ml_score_keys, backend):
 
 
 def run_benchmark(parameters):
+    raise Exception
     parameters["data_file"] = parameters["data_file"].replace("'", "")
     parameters["dfiles_num"] = parameters["dfiles_num"] or 1
     parameters["no_ml"] = parameters["no_ml"] or False

--- a/mortgage/mortgage_runner.py
+++ b/mortgage/mortgage_runner.py
@@ -62,7 +62,6 @@ def _run_ml(df, n_runs, mb, ml_keys, ml_score_keys, backend):
 
 
 def run_benchmark(parameters):
-    raise Exception
     parameters["data_file"] = parameters["data_file"].replace("'", "")
     parameters["dfiles_num"] = parameters["dfiles_num"] or 1
     parameters["no_ml"] = parameters["no_ml"] or False

--- a/mortgage/transform-data.py
+++ b/mortgage/transform-data.py
@@ -15,7 +15,7 @@ def main():
     try:
         source, dest = [os.path.abspath(x) for x in sys.argv[1:]]
     except TypeError:
-        sys.exit("Usage: %s source-path dest-path" % sys.argv[0])
+        raise TypeError("Usage: %s source-path dest-path" % sys.argv[0])
 
     for root, _, files in os.walk(source):
         if not files:

--- a/mortgage/transform-data.py
+++ b/mortgage/transform-data.py
@@ -15,7 +15,7 @@ def main():
     try:
         source, dest = [os.path.abspath(x) for x in sys.argv[1:]]
     except TypeError:
-        raise TypeError("Usage: %s source-path dest-path" % sys.argv[0])
+        raise ValueError("Usage: %s source-path dest-path" % sys.argv[0])
 
     for root, _, files in os.walk(source):
         if not files:

--- a/plasticc/plasticc_pandas_ibis.py
+++ b/plasticc/plasticc_pandas_ibis.py
@@ -613,6 +613,7 @@ def run_benchmark(parameters):
     etl_keys = ["t_readcsv", "t_etl", "t_connect"]
     ml_keys = ["t_train_test_split", "t_dmatrix", "t_training", "t_infer", "t_ml"]
     try:
+        raise Exception
         if not parameters["no_pandas"]:
             import_pandas_into_module_namespace(
                 namespace=run_benchmark.__globals__,

--- a/plasticc/plasticc_pandas_ibis.py
+++ b/plasticc/plasticc_pandas_ibis.py
@@ -688,4 +688,4 @@ def run_benchmark(parameters):
         return {"ETL": [etl_times_ibis, etl_times], "ML": [ml_times_ibis, ml_times]}
     except Exception:
         traceback.print_exc(file=sys.stdout)
-        sys.exit(1)
+        raise

--- a/plasticc/plasticc_pandas_ibis.py
+++ b/plasticc/plasticc_pandas_ibis.py
@@ -1,5 +1,3 @@
-import sys
-import traceback
 from collections import OrderedDict
 from functools import partial
 from timeit import default_timer as timer
@@ -612,81 +610,77 @@ def run_benchmark(parameters):
 
     etl_keys = ["t_readcsv", "t_etl", "t_connect"]
     ml_keys = ["t_train_test_split", "t_dmatrix", "t_training", "t_infer", "t_ml"]
-    try:
-        raise Exception
-        if not parameters["no_pandas"]:
-            import_pandas_into_module_namespace(
-                namespace=run_benchmark.__globals__,
-                mode=parameters["pandas_mode"],
-                ray_tmpdir=parameters["ray_tmpdir"],
-                ray_memory=parameters["ray_memory"],
+
+    if not parameters["no_pandas"]:
+        import_pandas_into_module_namespace(
+            namespace=run_benchmark.__globals__,
+            mode=parameters["pandas_mode"],
+            ray_tmpdir=parameters["ray_tmpdir"],
+            ray_memory=parameters["ray_memory"],
+        )
+
+    etl_times_ibis = None
+    ml_times_ibis = None
+    etl_times = None
+    ml_times = None
+
+    if not parameters["no_ibis"]:
+        train_final_ibis, test_final_ibis, etl_times_ibis = etl_all_ibis(
+            dataset_path=parameters["data_file"],
+            database_name=parameters["database_name"],
+            omnisci_server_worker=parameters["omnisci_server_worker"],
+            delete_old_database=not parameters["dnd"],
+            create_new_table=not parameters["dni"],
+            ipc_connection=parameters["ipc_connection"],
+            skip_rows=skip_rows,
+            validation=parameters["validation"],
+            dtypes=dtypes,
+            meta_dtypes=meta_dtypes,
+            etl_keys=etl_keys,
+            import_mode=parameters["import_mode"],
+            fragments_size=parameters["fragments_size"],
+        )
+
+        print_results(results=etl_times_ibis, backend="Ibis", unit="s")
+        etl_times_ibis["Backend"] = "Ibis"
+
+        if not parameters["no_ml"]:
+            print("using ml with dataframes from Ibis")
+            ml_times_ibis = ml(train_final_ibis, test_final_ibis, ml_keys)
+            print_results(results=ml_times_ibis, backend="Ibis", unit="s")
+            ml_times_ibis["Backend"] = "Ibis"
+
+    if not parameters["no_pandas"]:
+        train_final, test_final, etl_times = etl_all_pandas(
+            dataset_path=parameters["data_file"],
+            skip_rows=skip_rows,
+            dtypes=dtypes,
+            meta_dtypes=meta_dtypes,
+            etl_keys=etl_keys,
+            pandas_mode=parameters["pandas_mode"],
+        )
+
+        print_results(results=etl_times, backend=parameters["pandas_mode"], unit="s")
+        etl_times["Backend"] = parameters["pandas_mode"]
+
+        if not parameters["no_ml"]:
+            print("using ml with dataframes from Pandas")
+            ml_times = ml(train_final, test_final, ml_keys)
+            print_results(results=ml_times, backend=parameters["pandas_mode"], unit="s")
+            ml_times["Backend"] = parameters["pandas_mode"]
+
+    if parameters["validation"] and parameters["import_mode"] != "pandas":
+        print(
+            "WARNING: validation can not be performed, it works only for 'pandas' import mode, '{}' passed".format(
+                parameters["import_mode"]
             )
+        )
 
-        etl_times_ibis = None
-        ml_times_ibis = None
-        etl_times = None
-        ml_times = None
+    if parameters["validation"] and parameters["import_mode"] == "pandas":
+        compare_dataframes(
+            ibis_dfs=[train_final_ibis, test_final_ibis],
+            pandas_dfs=[train_final, test_final],
+            parallel_execution=True,
+        )
 
-        if not parameters["no_ibis"]:
-            train_final_ibis, test_final_ibis, etl_times_ibis = etl_all_ibis(
-                dataset_path=parameters["data_file"],
-                database_name=parameters["database_name"],
-                omnisci_server_worker=parameters["omnisci_server_worker"],
-                delete_old_database=not parameters["dnd"],
-                create_new_table=not parameters["dni"],
-                ipc_connection=parameters["ipc_connection"],
-                skip_rows=skip_rows,
-                validation=parameters["validation"],
-                dtypes=dtypes,
-                meta_dtypes=meta_dtypes,
-                etl_keys=etl_keys,
-                import_mode=parameters["import_mode"],
-                fragments_size=parameters["fragments_size"],
-            )
-
-            print_results(results=etl_times_ibis, backend="Ibis", unit="s")
-            etl_times_ibis["Backend"] = "Ibis"
-
-            if not parameters["no_ml"]:
-                print("using ml with dataframes from Ibis")
-                ml_times_ibis = ml(train_final_ibis, test_final_ibis, ml_keys)
-                print_results(results=ml_times_ibis, backend="Ibis", unit="s")
-                ml_times_ibis["Backend"] = "Ibis"
-
-        if not parameters["no_pandas"]:
-            train_final, test_final, etl_times = etl_all_pandas(
-                dataset_path=parameters["data_file"],
-                skip_rows=skip_rows,
-                dtypes=dtypes,
-                meta_dtypes=meta_dtypes,
-                etl_keys=etl_keys,
-                pandas_mode=parameters["pandas_mode"],
-            )
-
-            print_results(results=etl_times, backend=parameters["pandas_mode"], unit="s")
-            etl_times["Backend"] = parameters["pandas_mode"]
-
-            if not parameters["no_ml"]:
-                print("using ml with dataframes from Pandas")
-                ml_times = ml(train_final, test_final, ml_keys)
-                print_results(results=ml_times, backend=parameters["pandas_mode"], unit="s")
-                ml_times["Backend"] = parameters["pandas_mode"]
-
-        if parameters["validation"] and parameters["import_mode"] != "pandas":
-            print(
-                "WARNING: validation can not be performed, it works only for 'pandas' import mode, '{}' passed".format(
-                    parameters["import_mode"]
-                )
-            )
-
-        if parameters["validation"] and parameters["import_mode"] == "pandas":
-            compare_dataframes(
-                ibis_dfs=[train_final_ibis, test_final_ibis],
-                pandas_dfs=[train_final, test_final],
-                parallel_execution=True,
-            )
-
-        return {"ETL": [etl_times_ibis, etl_times], "ML": [ml_times_ibis, ml_times]}
-    except Exception:
-        traceback.print_exc(file=sys.stdout)
-        raise
+    return {"ETL": [etl_times_ibis, etl_times], "ML": [ml_times_ibis, ml_times]}

--- a/run_ibis_benchmark.py
+++ b/run_ibis_benchmark.py
@@ -1,8 +1,6 @@
 # coding: utf-8
 import argparse
 import os
-import sys
-import traceback
 import time
 
 import mysql.connector
@@ -509,9 +507,6 @@ def main():
                             remove_fields_from_dict(result_ml, ignore_fields_for_bd_report_ml)
                             db_reporter_ml.submit(result_ml)
 
-    except Exception:
-        traceback.print_exc(file=sys.stdout)
-        raise
     finally:
         if omnisci_server_worker:
             omnisci_server_worker.terminate()

--- a/run_ibis_benchmark.py
+++ b/run_ibis_benchmark.py
@@ -511,7 +511,7 @@ def main():
 
     except Exception:
         traceback.print_exc(file=sys.stdout)
-        sys.exit(1)
+        raise
     finally:
         if omnisci_server_worker:
             omnisci_server_worker.terminate()

--- a/run_ibis_tests.py
+++ b/run_ibis_tests.py
@@ -413,16 +413,14 @@ def main():
             tasks[task] = True if task in required_tasks else False
 
         if True not in list(tasks.values()):
-            print(
+            raise ValueError(
                 f"Only {list(tasks.keys())} are supported, {required_tasks} cannot find possible tasks"
             )
-            sys.exit(1)
 
         if args.python_version not in ["3.7", "3,6"]:
-            print(
+            raise NotImplementedError(
                 f"Only 3.7 and 3.6 python versions are supported, {args.python_version} is not supported"
             )
-            sys.exit(1)
 
         conda_env = CondaEnvironment(args.env_name)
         requirements_file = args.ci_requirements
@@ -601,10 +599,9 @@ def main():
             # sys.exit(1)
 
             if not args.data_file:
-                print(
+                raise ValueError(
                     "Parameter --data_file was received empty, but it is required for benchmarks"
                 )
-                sys.exit(1)
 
             benchmark_script_path = os.path.join(omniscript_path, "run_ibis_benchmark.py")
 
@@ -692,7 +689,7 @@ def main():
 
     except Exception:
         traceback.print_exc(file=sys.stdout)
-        sys.exit(1)
+        raise
 
     finally:
         if omnisci_server:

--- a/santander/santander_pandas_ibis.py
+++ b/santander/santander_pandas_ibis.py
@@ -1,6 +1,4 @@
 # coding: utf-8
-import sys
-import traceback
 import warnings
 from timeit import default_timer as timer
 
@@ -266,7 +264,6 @@ def ml(ml_data, target, ml_keys, ml_score_keys):
 
 
 def run_benchmark(parameters):
-    raise Exception
     check_support(parameters, unsupported_params=["dfiles_num", "gpu_memory", "optimizer"])
 
     parameters["data_file"] = parameters["data_file"].replace("'", "")
@@ -285,88 +282,85 @@ def run_benchmark(parameters):
     etl_keys = ["t_readcsv", "t_etl", "t_connect"]
     ml_keys = ["t_train_test_split", "t_ml", "t_train", "t_inference", "t_dmatrix"]
     ml_score_keys = ["mse", "cod"]
-    try:
+
+    if not parameters["no_pandas"]:
+        import_pandas_into_module_namespace(
+            namespace=run_benchmark.__globals__,
+            mode=parameters["pandas_mode"],
+            ray_tmpdir=parameters["ray_tmpdir"],
+            ray_memory=parameters["ray_memory"],
+        )
+
+    if not parameters["no_ibis"]:
+        ml_data_ibis, etl_times_ibis = etl_ibis(
+            filename=parameters["data_file"],
+            columns_names=columns_names,
+            columns_types=columns_types_ibis,
+            database_name=parameters["database_name"],
+            table_name=parameters["table"],
+            omnisci_server_worker=parameters["omnisci_server_worker"],
+            delete_old_database=not parameters["dnd"],
+            create_new_table=not parameters["dni"],
+            ipc_connection=parameters["ipc_connection"],
+            validation=parameters["validation"],
+            etl_keys=etl_keys,
+            import_mode=parameters["import_mode"],
+            fragments_size=parameters["fragments_size"],
+        )
+
+        print_results(results=etl_times_ibis, backend="Ibis", unit="s")
+        etl_times_ibis["Backend"] = "Ibis"
+
+    if not parameters["no_pandas"]:
+        ml_data, etl_times = etl_pandas(
+            filename=parameters["data_file"],
+            columns_names=columns_names,
+            columns_types=columns_types_pd,
+            etl_keys=etl_keys,
+        )
+        print_results(results=etl_times, backend=parameters["pandas_mode"], unit="s")
+        etl_times["Backend"] = parameters["pandas_mode"]
+
+    if not parameters["no_ml"]:
         if not parameters["no_pandas"]:
-            import_pandas_into_module_namespace(
-                namespace=run_benchmark.__globals__,
-                mode=parameters["pandas_mode"],
-                ray_tmpdir=parameters["ray_tmpdir"],
-                ray_memory=parameters["ray_memory"],
+            ml_scores, ml_times = ml(
+                ml_data=ml_data,
+                target="target",
+                ml_keys=ml_keys,
+                ml_score_keys=ml_score_keys,
             )
+            print_results(results=ml_times, backend=parameters["pandas_mode"], unit="s")
+            ml_times["Backend"] = parameters["pandas_mode"]
+            print_results(results=ml_scores, backend=parameters["pandas_mode"])
+            ml_scores["Backend"] = parameters["pandas_mode"]
 
         if not parameters["no_ibis"]:
-            ml_data_ibis, etl_times_ibis = etl_ibis(
-                filename=parameters["data_file"],
-                columns_names=columns_names,
-                columns_types=columns_types_ibis,
-                database_name=parameters["database_name"],
-                table_name=parameters["table"],
-                omnisci_server_worker=parameters["omnisci_server_worker"],
-                delete_old_database=not parameters["dnd"],
-                create_new_table=not parameters["dni"],
-                ipc_connection=parameters["ipc_connection"],
-                validation=parameters["validation"],
-                etl_keys=etl_keys,
-                import_mode=parameters["import_mode"],
-                fragments_size=parameters["fragments_size"],
+            ml_scores_ibis, ml_times_ibis = ml(
+                ml_data=ml_data_ibis,
+                target="target0",
+                ml_keys=ml_keys,
+                ml_score_keys=ml_score_keys,
             )
+            print_results(results=ml_times_ibis, backend="Ibis", unit="s")
+            ml_times_ibis["Backend"] = "Ibis"
+            print_results(results=ml_scores_ibis, backend="Ibis")
+            ml_scores_ibis["Backend"] = "Ibis"
 
-            print_results(results=etl_times_ibis, backend="Ibis", unit="s")
-            etl_times_ibis["Backend"] = "Ibis"
+    # Results validation block (comparison of etl_ibis and etl_pandas outputs)
+    if parameters["validation"]:
+        print("Validation of ETL query results ...")
+        cols_to_sort = ["var_0", "var_1", "var_2", "var_3", "var_4"]
 
-        if not parameters["no_pandas"]:
-            ml_data, etl_times = etl_pandas(
-                filename=parameters["data_file"],
-                columns_names=columns_names,
-                columns_types=columns_types_pd,
-                etl_keys=etl_keys,
-            )
-            print_results(results=etl_times, backend=parameters["pandas_mode"], unit="s")
-            etl_times["Backend"] = parameters["pandas_mode"]
+        ml_data_ibis = ml_data_ibis.rename(columns={"target0": "target"})
+        # compare_dataframes doesn't sort pandas dataframes
+        ml_data.sort_values(by=cols_to_sort, inplace=True)
 
-        if not parameters["no_ml"]:
-            if not parameters["no_pandas"]:
-                ml_scores, ml_times = ml(
-                    ml_data=ml_data,
-                    target="target",
-                    ml_keys=ml_keys,
-                    ml_score_keys=ml_score_keys,
-                )
-                print_results(results=ml_times, backend=parameters["pandas_mode"], unit="s")
-                ml_times["Backend"] = parameters["pandas_mode"]
-                print_results(results=ml_scores, backend=parameters["pandas_mode"])
-                ml_scores["Backend"] = parameters["pandas_mode"]
+        compare_dataframes(
+            ibis_dfs=[ml_data_ibis],
+            pandas_dfs=[ml_data],
+            sort_cols=cols_to_sort,
+            drop_cols=[],
+            parallel_execution=True,
+        )
 
-            if not parameters["no_ibis"]:
-                ml_scores_ibis, ml_times_ibis = ml(
-                    ml_data=ml_data_ibis,
-                    target="target0",
-                    ml_keys=ml_keys,
-                    ml_score_keys=ml_score_keys,
-                )
-                print_results(results=ml_times_ibis, backend="Ibis", unit="s")
-                ml_times_ibis["Backend"] = "Ibis"
-                print_results(results=ml_scores_ibis, backend="Ibis")
-                ml_scores_ibis["Backend"] = "Ibis"
-
-        # Results validation block (comparison of etl_ibis and etl_pandas outputs)
-        if parameters["validation"]:
-            print("Validation of ETL query results ...")
-            cols_to_sort = ["var_0", "var_1", "var_2", "var_3", "var_4"]
-
-            ml_data_ibis = ml_data_ibis.rename(columns={"target0": "target"})
-            # compare_dataframes doesn't sort pandas dataframes
-            ml_data.sort_values(by=cols_to_sort, inplace=True)
-
-            compare_dataframes(
-                ibis_dfs=[ml_data_ibis],
-                pandas_dfs=[ml_data],
-                sort_cols=cols_to_sort,
-                drop_cols=[],
-                parallel_execution=True,
-            )
-
-        return {"ETL": [etl_times_ibis, etl_times], "ML": [ml_times_ibis, ml_times]}
-    except Exception:
-        traceback.print_exc(file=sys.stdout)
-        raise
+    return {"ETL": [etl_times_ibis, etl_times], "ML": [ml_times_ibis, ml_times]}

--- a/santander/santander_pandas_ibis.py
+++ b/santander/santander_pandas_ibis.py
@@ -266,6 +266,7 @@ def ml(ml_data, target, ml_keys, ml_score_keys):
 
 
 def run_benchmark(parameters):
+    raise Exception
     check_support(parameters, unsupported_params=["dfiles_num", "gpu_memory", "optimizer"])
 
     parameters["data_file"] = parameters["data_file"].replace("'", "")

--- a/santander/santander_pandas_ibis.py
+++ b/santander/santander_pandas_ibis.py
@@ -368,4 +368,4 @@ def run_benchmark(parameters):
         return {"ETL": [etl_times_ibis, etl_times], "ML": [ml_times_ibis, ml_times]}
     except Exception:
         traceback.print_exc(file=sys.stdout)
-        sys.exit(1)
+        raise

--- a/server/server.py
+++ b/server/server.py
@@ -1,7 +1,6 @@
 import os
 import pathlib
 import signal
-import sys
 import threading
 import time
 
@@ -126,7 +125,7 @@ class OmnisciServer:
             time.sleep(5)
         except Exception as err:
             print("Failed", err)
-            sys.exit(1)
+            raise
 
     def _print_omnisci_output(self, stdout):
         for line in iter(stdout.readline, b""):
@@ -146,6 +145,6 @@ class OmnisciServer:
                 self.server_process = None
         except Exception as err:
             print("Failed to terminate server, error occured:", err)
-            sys.exit(1)
+            raise
 
         print("Server is terminated")

--- a/server_worker/server_worker.py
+++ b/server_worker/server_worker.py
@@ -1,6 +1,5 @@
 import gzip
 import subprocess
-import sys
 from timeit import default_timer as timer
 
 import ibis
@@ -146,8 +145,7 @@ class OmnisciServerWorker:
         elif not header:
             header_value = "false"
         else:
-            print("Wrong value of header argument!")
-            sys.exit(2)
+            raise ValueError("Wrong value of header argument!")
 
         schema_table = ibis.Schema(names=columns_names, types=columns_types)
 
@@ -313,8 +311,7 @@ class OmnisciServerWorker:
         if self._conn.exists_table(name=table_name, database=self.omnisci_server.database_name):
             return self._imported_pd_df[table_name]
         else:
-            print("Table", table_name, "doesn't exist!")
-            sys.exit(4)
+            raise ValueError("Table", table_name, "doesn't exist!")
 
     def execute_sql_query(self, query):
         "Execute SQL query directly in the OmniSciDB"

--- a/taxi/taxibench_pandas_ibis.py
+++ b/taxi/taxibench_pandas_ibis.py
@@ -670,4 +670,4 @@ def run_benchmark(parameters):
         return {"ETL": [etl_results_ibis, etl_results], "ML": []}
     except Exception:
         traceback.print_exc(file=sys.stdout)
-        sys.exit(1)
+        raise

--- a/taxi/taxibench_pandas_ibis.py
+++ b/taxi/taxibench_pandas_ibis.py
@@ -616,6 +616,7 @@ def run_benchmark(parameters):
     if parameters["dfiles_num"] <= 0:
         raise ValueError(f"Bad number of data files specified: {parameters['dfiles_num']}")
     try:
+        raise Exception
         if not parameters["no_pandas"]:
             import_pandas_into_module_namespace(
                 namespace=run_benchmark.__globals__,

--- a/taxi/taxibench_pandas_ibis.py
+++ b/taxi/taxibench_pandas_ibis.py
@@ -1,6 +1,4 @@
 # Original SQL queries can be found here https://tech.marksblogg.com/billion-nyc-taxi-rides-nvidia-pascal-titan-x-mapd.html
-import sys
-import traceback
 from timeit import default_timer as timer
 
 import pandas as pd
@@ -615,60 +613,56 @@ def run_benchmark(parameters):
 
     if parameters["dfiles_num"] <= 0:
         raise ValueError(f"Bad number of data files specified: {parameters['dfiles_num']}")
-    try:
-        raise Exception
-        if not parameters["no_pandas"]:
-            import_pandas_into_module_namespace(
-                namespace=run_benchmark.__globals__,
-                mode=parameters["pandas_mode"],
-                ray_tmpdir=parameters["ray_tmpdir"],
-                ray_memory=parameters["ray_memory"],
-            )
 
-        etl_results_ibis = None
-        etl_results = None
-        pd_queries_outputs = {} if parameters["validation"] else None
-        if not parameters["no_pandas"]:
-            pandas_files_limit = parameters["dfiles_num"]
-            filename = files_names_from_pattern(parameters["data_file"])[:pandas_files_limit]
-            etl_results = etl_pandas(
-                filename=filename,
-                files_limit=pandas_files_limit,
-                columns_names=columns_names,
-                columns_types=columns_types,
-                output_for_validation=pd_queries_outputs,
-                pandas_mode=parameters["pandas_mode"],
-            )
+    if not parameters["no_pandas"]:
+        import_pandas_into_module_namespace(
+            namespace=run_benchmark.__globals__,
+            mode=parameters["pandas_mode"],
+            ray_tmpdir=parameters["ray_tmpdir"],
+            ray_memory=parameters["ray_memory"],
+        )
 
-            print_results(results=etl_results, backend=parameters["pandas_mode"], unit="ms")
-            etl_results["Backend"] = parameters["pandas_mode"]
-            etl_results["dfiles_num"] = parameters["dfiles_num"]
-            etl_results["dataset_size"] = get_ny_taxi_dataset_size(parameters["dfiles_num"])
+    etl_results_ibis = None
+    etl_results = None
+    pd_queries_outputs = {} if parameters["validation"] else None
+    if not parameters["no_pandas"]:
+        pandas_files_limit = parameters["dfiles_num"]
+        filename = files_names_from_pattern(parameters["data_file"])[:pandas_files_limit]
+        etl_results = etl_pandas(
+            filename=filename,
+            files_limit=pandas_files_limit,
+            columns_names=columns_names,
+            columns_types=columns_types,
+            output_for_validation=pd_queries_outputs,
+            pandas_mode=parameters["pandas_mode"],
+        )
 
-        if not parameters["no_ibis"]:
-            etl_results_ibis = etl_ibis(
-                filename=parameters["data_file"],
-                files_limit=parameters["dfiles_num"],
-                columns_names=columns_names,
-                columns_types=columns_types,
-                database_name=parameters["database_name"],
-                table_name=parameters["table"],
-                omnisci_server_worker=parameters["omnisci_server_worker"],
-                delete_old_database=not parameters["dnd"],
-                ipc_connection=parameters["ipc_connection"],
-                create_new_table=not parameters["dni"],
-                input_for_validation=pd_queries_outputs,
-                import_mode=parameters["import_mode"],
-                fragments_size=parameters["fragments_size"],
-                debug_mode=parameters["debug_mode"],
-            )
+        print_results(results=etl_results, backend=parameters["pandas_mode"], unit="ms")
+        etl_results["Backend"] = parameters["pandas_mode"]
+        etl_results["dfiles_num"] = parameters["dfiles_num"]
+        etl_results["dataset_size"] = get_ny_taxi_dataset_size(parameters["dfiles_num"])
 
-            print_results(results=etl_results_ibis, backend="Ibis", unit="ms")
-            etl_results_ibis["Backend"] = "Ibis"
-            etl_results_ibis["dfiles_num"] = parameters["dfiles_num"]
-            etl_results_ibis["dataset_size"] = get_ny_taxi_dataset_size(parameters["dfiles_num"])
+    if not parameters["no_ibis"]:
+        etl_results_ibis = etl_ibis(
+            filename=parameters["data_file"],
+            files_limit=parameters["dfiles_num"],
+            columns_names=columns_names,
+            columns_types=columns_types,
+            database_name=parameters["database_name"],
+            table_name=parameters["table"],
+            omnisci_server_worker=parameters["omnisci_server_worker"],
+            delete_old_database=not parameters["dnd"],
+            ipc_connection=parameters["ipc_connection"],
+            create_new_table=not parameters["dni"],
+            input_for_validation=pd_queries_outputs,
+            import_mode=parameters["import_mode"],
+            fragments_size=parameters["fragments_size"],
+            debug_mode=parameters["debug_mode"],
+        )
 
-        return {"ETL": [etl_results_ibis, etl_results], "ML": []}
-    except Exception:
-        traceback.print_exc(file=sys.stdout)
-        raise
+        print_results(results=etl_results_ibis, backend="Ibis", unit="ms")
+        etl_results_ibis["Backend"] = "Ibis"
+        etl_results_ibis["dfiles_num"] = parameters["dfiles_num"]
+        etl_results_ibis["dataset_size"] = get_ny_taxi_dataset_size(parameters["dfiles_num"])
+
+    return {"ETL": [etl_results_ibis, etl_results], "ML": []}


### PR DESCRIPTION
Signed-off-by: Alexander Myskov <alexander.myskov@intel.com>

`sys.exit` calls were removed to eliminate false positive CI checks, also unnecessary tracebacks prints were removed (now it is printed only in `run_ibis_tests.py` only).