### PR TITLE
[CI] rename reporting field

### DIFF
--- a/report/report.py
+++ b/report/report.py
@@ -14,7 +14,7 @@ class DbReport:
         self.__predefined_field_values["Architecture"] = platform.architecture()[0]
         self.__predefined_field_values["Machine"] = platform.machine()
         self.__predefined_field_values["Node"] = platform.node()
-        self.__predefined_field_values["System"] = platform.system()
+        self.__predefined_field_values["OS"] = platform.system()
         self.__predefined_field_values["CPUCount"] = os.cpu_count()
 
         def match_and_assign(tag, pattern):
@@ -54,7 +54,7 @@ class DbReport:
             "Architecture": "VARCHAR(500) NOT NULL",
             "Machine": "VARCHAR(500) NOT NULL",
             "Node": "VARCHAR(500) NOT NULL",
-            "System": "VARCHAR(500) NOT NULL",
+            "OS": "VARCHAR(500) NOT NULL",
             "CPUCount": "VARCHAR(500) NOT NULL",
             "CPUModel": "VARCHAR(500) NOT NULL",
             "CPUMHz": "VARCHAR(500) NOT NULL",


### PR DESCRIPTION
Signed-off-by: Alexander Myskov <alexander.myskov@intel.com>

It was found that CI fails with message
`_mysql_connector.MySQLInterfaceError: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'System VARCHAR(500) NOT NULL,CPUCount VARCHAR(500) NOT NULL,CPUModel VARCHAR(500' at line 1`
Empirically was found that SQL query fails because of `System` field name (some time ago OS on machine with SQL server was updated and MySQL probably was updated as well and now `System` name can be prohibited). So `System` name was replaced `OS` name for omniscripts and MySQL tables.