### PR TITLE
pin pandas version

### DIFF
--- a/ci_requirements.yml
+++ b/ci_requirements.yml
@@ -8,7 +8,7 @@ dependencies:
   - mysql
   - mysql-connector-python
   - numpy>=1.11
-  - pandas>=1.0.0
+  - pandas>=1.0.0,<=1.1.5
   - conda
   - xgboost==1.0.2
   - daal4py=0.2020.2


### PR DESCRIPTION
Signed-off-by: Alexander Myskov <alexander.myskov@intel.com>

It was found that after Pandas 1.2.0 was released, NYC taxi benchmark using OmniSciDB/Ibis failed, so we are trying to pin Pandas version to fix it.