### PR TITLE
[CI] rename modin env file

### DIFF
--- a/run_ibis_tests.py
+++ b/run_ibis_tests.py
@@ -450,7 +450,7 @@ def main():
                     "--name",
                     f"{args.env_name}",
                     "--file",
-                    "environment.yml",
+                    "environment-dev.yml",
                 ]
                 if args.modin_pkgs_dir:
                     os.environ["PYTHONPATH"] = (


### PR DESCRIPTION
Signed-off-by: Alexander Myskov <alexander.myskov@intel.com>

We need to correct env file since it was renamed in modin  https://github.com/modin-project/modin/pull/2668.