### PR TITLE
[CI] pin pyarrow to 2.0 version

### DIFF
--- a/ci_requirements.yml
+++ b/ci_requirements.yml
@@ -17,8 +17,8 @@ dependencies:
   - black=19.10b0
   - flake8
   - Cython
-  - pyarrow==1.0
-  - arrow-cpp==1.0
+  - pyarrow==2.0
+  - arrow-cpp==2.0
   - cmake>=3.15
   - pip:
       - xgboost >=1.3


### PR DESCRIPTION
Signed-off-by: Alexander Myskov <alexander.myskov@intel.com>

`intel-ai/omniscidb` now supports `pyarrow 2.0`, so version here can be switched too.