### PR TITLE
[CI] pin daal

### DIFF
--- a/ci_requirements.yml
+++ b/ci_requirements.yml
@@ -11,6 +11,7 @@ dependencies:
   - pandas>=1.0.0
   - conda
   - daal4py=0.2020.2
+  - daal=2020.2
   - scikit-learn<0.23.0   # in 0.23.0 we see undefined symbols: ImportError: cannot import name '_infer_dimension_' from 'sklearn.decomposition._pca'
   - pip
   - psutil


### PR DESCRIPTION
Signed-off-by: Alexander Myskov <alexander.myskov@intel.com>

It was found that `daal` version not correlates with installed `daal4py` version and after new `daal` release, compatibility of `daal` and `daal4py` became broken, reproducer:
```
conda install daal4py=0.2020.2 -c intel

python -c "import daal4py.sklearn.linear_model as lm"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/miniconda3/envs/test/lib/python3.7/site-packages/daal4py/__init__.py", line 2, in <module>
    from _daal4py import *
ImportError: libdaal_core.so: cannot open shared object file: No such file or directory

conda list | grep daal
daal                      2021.1.1               intel_79    intel
daal4py                   0.2020.2         py37h533f8aa_7    intel
```
So we are pinning `daal` to the pinned `daal4py` version to restore `daal` and `daaal4py` compatibility.