### PR TITLE
Added dockerfiles to run benchmarks in ray and omnisci from conda configurations

### DIFF
--- a/docker/Dockerfile.omnisci-from-conda
+++ b/docker/Dockerfile.omnisci-from-conda
@@ -1,0 +1,50 @@
+# Create images from this container like this (up from modin and omniscripts repo roots):
+#
+# tar cf omniscripts/docker/modin-and-omniscripts.tar modin omniscripts
+#
+# docker build -t modin-project/benchmarks-ci-omnisci:${BUILD_NUMBER} -f omniscripts/docker/Dockerfile.omnisci-from-conda omniscripts/docker
+
+FROM ubuntu:20.04
+ENV http_proxy ${http_proxy}
+ENV https_proxy ${https_proxy}
+
+RUN apt-get update --yes \
+    && apt-get install wget git --yes && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV USER modin
+ENV UID 1000
+ENV HOME /home/$USER
+
+RUN adduser --disabled-password \
+    --gecos "Non-root user" \
+    --uid $UID \
+    --home $HOME \
+    $USER
+
+WORKDIR ${HOME}
+ADD modin-and-omniscripts.tar .
+RUN chown -R ${USER}:${USER} modin omniscripts
+RUN mkdir /dataset
+
+# Done with actions that require root, switching to user mode
+
+USER ${USER}
+SHELL ["/bin/bash", "--login", "-c"]
+
+ENV CONDA_DIR ${HOME}/miniconda
+
+RUN wget -nv https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /tmp/miniconda3.sh && \
+    bash /tmp/miniconda3.sh -b -p "${CONDA_DIR}" -f -u && \
+    "${CONDA_DIR}/bin/conda" init bash && \
+    rm -f /tmp/miniconda3.sh && \
+    echo ". '${CONDA_DIR}/etc/profile.d/conda.sh'" >> "${HOME}/.profile"
+
+# Adding channel_priority strict to the following commands makes conda fail.
+# Luckily we don't need it here because conda resolves environment fairly quickly.
+RUN conda update -n base -c defaults conda -y &&                                    \
+    conda env create --file=modin/requirements/env_omnisci.yml &&                   \
+    conda activate modin_on_omnisci &&                                              \
+    conda env update -n modin_on_omnisci --file=omniscripts/ci_requirements.yml &&  \
+    conda clean --all --yes &&                                                      \
+    cd modin && pip install -e .

--- a/docker/Dockerfile.ray
+++ b/docker/Dockerfile.ray
@@ -1,0 +1,49 @@
+# Create images from this container like this (up from modin and omniscripts repo roots):
+#
+# tar cf omniscripts/docker/modin-and-omniscripts.tar modin omniscripts
+#
+# docker build -t modin-project/benchmarks-ci-ray:${BUILD_NUMBER} -f omniscripts/docker/Dockerfile.ray omniscripts/docker
+
+FROM ubuntu:20.04
+ENV http_proxy ${http_proxy}
+ENV https_proxy ${https_proxy}
+
+RUN apt-get update --yes \
+    && apt-get install wget git --yes && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV USER modin
+ENV UID 1000
+ENV HOME /home/$USER
+
+RUN adduser --disabled-password \
+    --gecos "Non-root user" \
+    --uid $UID \
+    --home $HOME \
+    $USER
+
+WORKDIR ${HOME}
+ADD modin-and-omniscripts.tar .
+RUN chown -R ${USER}:${USER} modin omniscripts
+RUN mkdir /dataset
+
+# Done with actions that require root, switching to user mode
+
+USER ${USER}
+SHELL ["/bin/bash", "--login", "-c"]
+
+ENV CONDA_DIR ${HOME}/miniconda
+
+RUN wget -nv https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /tmp/miniconda3.sh && \
+    bash /tmp/miniconda3.sh -b -p "${CONDA_DIR}" -f -u && \
+    "${CONDA_DIR}/bin/conda" init bash && \
+    rm -f /tmp/miniconda3.sh && \
+    echo ". '${CONDA_DIR}/etc/profile.d/conda.sh'" >> "${HOME}/.profile"
+
+RUN conda update -n base -c defaults conda -y &&                        \
+    conda config --set channel_priority strict &&                       \
+    conda env create --file=modin/environment-dev.yml &&                \
+    conda activate modin &&                                             \
+    conda env update -n modin --file=omniscripts/ci_requirements.yml && \
+    conda clean --all --yes &&                                          \
+    cd modin && pip install -e .


### PR DESCRIPTION
All benchmarks in CI should be run in docker containers. These files are necessary to implement it this way.