### PR TITLE
[CI] Avoid Modin dependencies installation and use correct Omnisci engine name

### DIFF
--- a/run_ibis_tests.py
+++ b/run_ibis_tests.py
@@ -416,8 +416,6 @@ def main():
                         if os.getenv("PYTHONPATH")
                         else args.modin_pkgs_dir
                     )
-                print("INSTALLATION OF MODIN DEPENDENCIES")
-                conda_env.update(str(args.env_name), "environment-dev.yml", cwd=args.modin_path)
 
                 print("MODIN INSTALLATION")
                 conda_env.run(install_cmdline, cwd=args.modin_path)

--- a/run_ibis_tests.py
+++ b/run_ibis_tests.py
@@ -417,8 +417,10 @@ def main():
                         else args.modin_pkgs_dir
                     )
 
+                install_cmdline_modin_pip = ["pip", "install", ".[ray]"]
+
                 print("MODIN INSTALLATION")
-                conda_env.run(install_cmdline, cwd=args.modin_path)
+                conda_env.run(install_cmdline_modin_pip, cwd=args.modin_path)
 
             # trying to install dbe extension if omnisci generated it
             executables_path = os.path.dirname(args.executable)

--- a/taxi/taxibench_pandas_ibis.py
+++ b/taxi/taxibench_pandas_ibis.py
@@ -472,7 +472,7 @@ def etl_pandas(
     concatenated_df = pd.concat(df_from_each_file, ignore_index=True)
     # this is to trigger data import in `MOdin_on_omnisci` mode
     if pandas_mode == "Modin_on_omnisci":
-        from modin.experimental.engines.omnisci_on_ray.frame.omnisci_worker import OmnisciServer
+        from modin.experimental.engines.omnisci_on_native.frame.omnisci_worker import OmnisciServer
 
         concatenated_df.shape
         concatenated_df._query_compiler._modin_frame._partitions[0][


### PR DESCRIPTION
Also corrected `OmnisciServer` import to fix taxi bench.

Signed-off-by: Alexander Myskov <alexander.myskov@intel.com>