### PR TITLE
update pyarrow: 3.0 -> 5.0

### DIFF
--- a/ci_requirements.yml
+++ b/ci_requirements.yml
@@ -17,8 +17,8 @@ dependencies:
   - black=19.10b0
   - flake8
   - Cython
-  - pyarrow==5.0
-  - arrow-cpp==5.0
+  - pyarrow<=5.0
+  - arrow-cpp<=5.0
   - cmake>=3.15
   # pip with old git failed build asv from master; conflict with PEP440
   - git>=2.0.0

--- a/ci_requirements.yml
+++ b/ci_requirements.yml
@@ -17,8 +17,8 @@ dependencies:
   - black=19.10b0
   - flake8
   - Cython
-  - pyarrow==3.0
-  - arrow-cpp==3.0
+  - pyarrow==5.0
+  - arrow-cpp==5.0
   - cmake>=3.15
   # pip with old git failed build asv from master; conflict with PEP440
   - git>=2.0.0


### PR DESCRIPTION
`omniscidb` from `https://github.com/intel-ai/omniscidb/tree/modin` started to work with `pyarrow==5.0`, so we should update `omniscripts` env file that used in tests.

Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>