### PR TITLE
Rework no-deps mode

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -7,11 +7,6 @@ from collections import OrderedDict
 import psutil
 from tempfile import mkstemp
 
-try:
-    from braceexpand import braceexpand
-except ModuleNotFoundError:
-    braceexpand = None
-
 conversions = {"ms": 1000, "s": 1, "m": 1 / 60, "": 1}
 repository_root_directory = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 directories = {"repository_root": repository_root_directory}
@@ -243,6 +238,11 @@ def expand_braces(pattern: str):
 
 
 def files_names_from_pattern(files_pattern):
+    try:
+        from braceexpand import braceexpand
+    except ModuleNotFoundError:
+        braceexpand = None
+
     data_files_names = None
     path_expander = glob.glob
     data_files_names = (

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -8,11 +8,6 @@ import psutil
 from tempfile import mkstemp
 
 try:
-    from .s3_client import s3_client
-except ModuleNotFoundError:
-    s3_client = None
-
-try:
     from braceexpand import braceexpand
 except ModuleNotFoundError:
     braceexpand = None
@@ -43,9 +38,6 @@ ny_taxi_data_files_sizes_MB = OrderedDict(
         "trips_xas.csv": 8600,
         "trips_xat.csv": 8600,
     }
-)
-s3_client_abscence_error = (
-    "`s3_client` wasn't imported, please ensure `s3fs` package is installed."
 )
 
 
@@ -258,8 +250,8 @@ def files_names_from_pattern(files_pattern):
     )
 
     if "://" in files_pattern:
-        if not s3_client:
-            raise RuntimeError(s3_client_abscence_error)
+        from .s3_client import s3_client
+
         if all(map(s3_client.s3like, data_files_names)):
             path_expander = s3_client.glob
         else:
@@ -444,8 +436,8 @@ def memory_usage():
 def getsize(filename: str):
     """Return size of filename in MB"""
     if "://" in filename:
-        if not s3_client:
-            raise RuntimeError(s3_client_abscence_error)
+        from .s3_client import s3_client
+
         if s3_client.s3like(filename):
             return s3_client.getsize(filename) / 1024 / 1024
         raise ValueError(f"bad s3like link: {filename}")
@@ -617,8 +609,8 @@ def get_dir_size(start_path="."):
     """
     total_size = 0
     if "://" in start_path:
-        if not s3_client:
-            raise RuntimeError(s3_client_abscence_error)
+        from .s3_client import s3_client
+
         if s3_client.s3like(start_path):
             total_size = s3_client.du(start_path)
         else:

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -264,8 +264,6 @@ def files_names_from_pattern(files_pattern):
             path_expander = s3_client.glob
         else:
             raise ValueError(f"some of s3like links are bad: {data_files_names}")
-    else:
-        data_files_names = expand_braces(files_pattern)
 
     return sorted([x for f in data_files_names for x in path_expander(f)])
 


### PR DESCRIPTION
Signed-off-by: Alexander Myskov <alexander.myskov@intel.com>

This PR makes `no-deps` mode default. Now `braceexpand` and `s3fs` are used only if they are available, otherwise our reduced version of `braceexpand` will be used. In the cases when S3 files are passed and `s3fs` is not available, exception is raised.