### PR TITLE
use 'cookiecutter' for work with 'flyteorg/flytekit-python-template.git'

### DIFF
--- a/flyte/docs/Setup Flyte local Sandbox.md
+++ b/flyte/docs/Setup Flyte local Sandbox.md
@@ -26,8 +26,7 @@ The Flyte Sandbox is a fully standalone minimal environment for running Flyte. I
 
 1. Clone repo with flytekit-python-template
 
-   >git clone https://github.com/flyteorg/flytekit-python-template.git myflyteapp
-   >cd myflyteapp
+   > cookiecutter https://github.com/flyteorg/flytekit-python-template.git --directory="simple-example" -c 005f8830448095a50e42c2e60e764d00fbed4eb8 && cd flyte_example
 
 2. Start Docker daemon
 


### PR DESCRIPTION
Resolves #285.

`cookiecutter` is installed when the `pip install flytekit --upgrade` command is run.

The repository with the template has no tags, so I use the latest commit.

Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>