### PR TITLE
Increase minimum python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ Results can be stored in MySQL database and visualized using Grafana charts.
 
 Sample run taxi benchmark command line:
 ```
-python3 run_modin_tests.py --env_name modin-test --env_check True --python_version 3.7 -task benchmark --save_env True --bench_name ny_taxi --iters 5 --ci_requirements ./ci_requirements.yml -data_file '${DATASETS_PWD}/taxi/trips_xa{a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t}.csv'
+python3 run_modin_tests.py --env_name modin-test --env_check True --python_version 3.8 -task benchmark --save_env True --bench_name ny_taxi --iters 5 --ci_requirements ./ci_requirements.yml -data_file '${DATASETS_PWD}/taxi/trips_xa{a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t}.csv'
 ```
 
 Sample run census benchmark command line:
 ```
-python3 run_modin_tests.py --env_name modin-test --env_check True --python_version 3.7 -task benchmark -bench_name census -data_file ./census/ipums_education2income_1970-2010.csv.gz -pandas_mode Modin_on_omnisci -ray_tmpdir ./tmp
+python3 run_modin_tests.py --env_name modin-test --env_check True --python_version 3.8 -task benchmark -bench_name census -data_file ./census/ipums_education2income_1970-2010.csv.gz -pandas_mode Modin_on_omnisci -ray_tmpdir ./tmp
 ```
 
 More examples could be find in scripts of `teamcity_build_scripts`. 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ Results can be stored in MySQL database and visualized using Grafana charts.
 
 Sample run taxi benchmark command line:
 ```
-python3 run_modin_tests.py --env_name modin-test --env_check True --python_version 3.8 -task benchmark --save_env True --bench_name ny_taxi --iters 5 --ci_requirements ./ci_requirements.yml -data_file '${DATASETS_PWD}/taxi/trips_xa{a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t}.csv'
+python3 run_modin_tests.py --env_name modin-test --env_check True -task benchmark --save_env True --bench_name ny_taxi --iters 5 --ci_requirements ./ci_requirements.yml -data_file '${DATASETS_PWD}/taxi/trips_xa{a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t}.csv'
 ```
 
 Sample run census benchmark command line:
 ```
-python3 run_modin_tests.py --env_name modin-test --env_check True --python_version 3.8 -task benchmark -bench_name census -data_file ./census/ipums_education2income_1970-2010.csv.gz -pandas_mode Modin_on_omnisci -ray_tmpdir ./tmp
+python3 run_modin_tests.py --env_name modin-test --env_check True -task benchmark -bench_name census -data_file ./census/ipums_education2income_1970-2010.csv.gz -pandas_mode Modin_on_omnisci -ray_tmpdir ./tmp
 ```
 
 More examples could be find in scripts of `teamcity_build_scripts`. 

--- a/run_modin_tests.py
+++ b/run_modin_tests.py
@@ -21,9 +21,9 @@ def main(raw_args=None):
             f"Only {list(tasks.keys())} are supported, {required_tasks} cannot find possible tasks"
         )
 
-    if args.python_version not in ["3.7", "3,6"]:
+    if args.python_version not in ["3.8"]:
         raise NotImplementedError(
-            f"Only 3.7 and 3.6 python versions are supported, {args.python_version} is not supported"
+            f"Only 3.8 python version is supported, {args.python_version} is not supported"
         )
 
     if args.env_name is not None:

--- a/utils_base_env/utils_base_env.py
+++ b/utils_base_env/utils_base_env.py
@@ -170,7 +170,7 @@ def prepare_parser():
         "-py",
         "--python_version",
         dest="python_version",
-        default="3.7",
+        default="3.8",
         help="Python version that should be installed in conda env.",
     )
     # Modin


### PR DESCRIPTION
Signed-off-by: Alexander Myskov <alexander.myskov@intel.com>

pandas and Modin now requires minimum python 3.8 version, so we need to meet these requirement too.
OmniSci in the CI configuration now is built with python 3.8 too.