### PR TITLE
Correct reporting

### DIFF
--- a/report/report.py
+++ b/report/report.py
@@ -11,7 +11,7 @@ class DbReport:
     def __init_predefined_field_values(self, initial_values):
         # System parameters
         self.__predefined_field_values["ServerName"] = (
-            os.environ["HOST_NAME"] or socket.gethostname()
+            os.environ["HOST_NAME"] if "HOST_NAME" in os.environ else socket.gethostname()
         )
         self.__predefined_field_values["Architecture"] = platform.architecture()[0]
         self.__predefined_field_values["Machine"] = platform.machine()

--- a/report/report.py
+++ b/report/report.py
@@ -10,7 +10,9 @@ class DbReport:
 
     def __init_predefined_field_values(self, initial_values):
         # System parameters
-        self.__predefined_field_values["ServerName"] = socket.gethostname()
+        self.__predefined_field_values["ServerName"] = (
+            os.environ["HOST_NAME"] or socket.gethostname()
+        )
         self.__predefined_field_values["Architecture"] = platform.architecture()[0]
         self.__predefined_field_values["Machine"] = platform.machine()
         self.__predefined_field_values["Node"] = platform.node()


### PR DESCRIPTION
Signed-off-by: Alexander Myskov <alexander.myskov@intel.com>

We have started to use TeamCity agents inside containers, but the command `socket.gethostname()` inside a container outputs container id, that breaks results representation.