### PR TITLE
[TAXI]: Take columns in the exact order as they're stored

### DIFF
--- a/taxi/taxibench_pandas_modin.py
+++ b/taxi/taxibench_pandas_modin.py
@@ -78,12 +78,12 @@ def q3(df, pandas_mode):
     if pandas_mode != "Modin_on_omnisci":
         transformed = pd.DataFrame(
             {
-                "passenger_count": df["passenger_count"],
                 "pickup_datetime": df["pickup_datetime"].dt.year,
+                "passenger_count": df["passenger_count"],
             }
         )
         q3_output = (
-            transformed.groupby(["passenger_count", "pickup_datetime"]).size().reset_index()
+            transformed.groupby(["pickup_datetime", "passenger_count"]).size().reset_index()
         )
     else:
         df["pickup_datetime"] = df["pickup_datetime"].dt.year

--- a/taxi/taxibench_pandas_modin.py
+++ b/taxi/taxibench_pandas_modin.py
@@ -83,7 +83,7 @@ def q3(df, pandas_mode):
             }
         )
         q3_output = (
-            transformed.groupby(["pickup_datetime", "passenger_count"]).size().reset_index()
+            transformed.groupby(["passenger_count", "pickup_datetime"]).size().reset_index()
         )
     else:
         df["pickup_datetime"] = df["pickup_datetime"].dt.year


### PR DESCRIPTION
Taking columns in the exact order as they're stored in the frame allows us to skip [labels reordering](https://github.com/modin-project/modin/blob/c30ab4c132295b1e168fbb06a050c76554759e11/modin/core/dataframe/pandas/dataframe/dataframe.py#L859) in the following `.groupby()` call which inquiries data reshuffling.

Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>