### PR TITLE
[TAXI] Use `as_index=False` in groupby instead of `.reset_index()` after groupby

### DIFF
--- a/taxi/taxibench_pandas_modin.py
+++ b/taxi/taxibench_pandas_modin.py
@@ -82,9 +82,9 @@ def q3(df, pandas_mode):
                 "pickup_datetime": df["pickup_datetime"].dt.year,
             }
         )
-        q3_output = (
-            transformed.groupby(["pickup_datetime", "passenger_count"], as_index=False).size()
-        )
+        q3_output = transformed.groupby(
+            ["pickup_datetime", "passenger_count"], as_index=False
+        ).size()
     else:
         df["pickup_datetime"] = df["pickup_datetime"].dt.year
         q3_output = df.groupby(["passenger_count", "pickup_datetime"]).size()
@@ -126,7 +126,9 @@ def q4(df, pandas_mode):
             }
         )
         q4_output = (
-            transformed.groupby(["passenger_count", "pickup_datetime", "trip_distance"], as_index=False)
+            transformed.groupby(
+                ["passenger_count", "pickup_datetime", "trip_distance"], as_index=False
+            )
             .size()
             .sort_values(by=["pickup_datetime", "size"], ascending=[True, False])
         )

--- a/taxi/taxibench_pandas_modin.py
+++ b/taxi/taxibench_pandas_modin.py
@@ -83,7 +83,7 @@ def q3(df, pandas_mode):
             }
         )
         q3_output = (
-            transformed.groupby(["pickup_datetime", "passenger_count"]).size().reset_index()
+            transformed.groupby(["pickup_datetime", "passenger_count"], as_index=False).size()
         )
     else:
         df["pickup_datetime"] = df["pickup_datetime"].dt.year
@@ -126,9 +126,8 @@ def q4(df, pandas_mode):
             }
         )
         q4_output = (
-            transformed.groupby(["passenger_count", "pickup_datetime", "trip_distance"])
+            transformed.groupby(["passenger_count", "pickup_datetime", "trip_distance"], as_index=False)
             .size()
-            .reset_index()
             .sort_values(by=["pickup_datetime", 0], ascending=[True, False])
         )
     else:

--- a/taxi/taxibench_pandas_modin.py
+++ b/taxi/taxibench_pandas_modin.py
@@ -128,7 +128,7 @@ def q4(df, pandas_mode):
         q4_output = (
             transformed.groupby(["passenger_count", "pickup_datetime", "trip_distance"], as_index=False)
             .size()
-            .sort_values(by=["pickup_datetime", 0], ascending=[True, False])
+            .sort_values(by=["pickup_datetime", "size"], ascending=[True, False])
         )
     else:
         df["pickup_datetime"] = df["pickup_datetime"].dt.year


### PR DESCRIPTION
Accumulating as much as possible into a single API call is good for Modin's perf

Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>