### PR TITLE
DATASETS_ROOT is now required to be defined by `all.sh`

### DIFF
--- a/docker/e2e-hdk/README.md
+++ b/docker/e2e-hdk/README.md
@@ -6,10 +6,10 @@ This is a folder with everything necessary to reproduce key benchmarks.
 
 ### How to run 
 0. You need to have complete omniscripts repository before running, so clone it or download current version.
-1. Open `all.sh` and modify `DATASETS_ROOT`. This is where the datasets will be stored, so expect this filder to have 170GB of data. The path needs to be absolute, otherwise docker mounting will fail.
+1. Configure `DATASETS_ROOT`. This is where the datasets will be stored, so expect this filder to have 170GB of data. To do that run `export DATASETS_ROOT=**datasets path**`. 
 2. *Optional.* Open `all.sh` and modify `RESULTS` variable. This is where the benchmark results will be stored. By default they are stored in the current folder.
 3. Change dir to this folder `cd omniscripts/docker/e2e-hdk`
-4. Run `./all.sh` to benchmark. Results will be stored in `RESULTS` folder (in the current folder by default).
+4. Run `./all.sh` to benchmark. Results will be stored in `RESULTS` folder (in the current folder in `results` dir by default).
 ### Files
 - `all.sh` - Main script to run everything. Before running it, change `DATASETS_ROOT` to a location where you want to store datasets (around 170GB).
 - `load_data.sh` - script that loads datasets

--- a/docker/e2e-hdk/all.sh
+++ b/docker/e2e-hdk/all.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -eu
 # Set location to store datasets, 
-# WARNING: paths need to be absolute, otherwise docker will not mount
+# WARNING: paths need to be absolute, otherwise docker will not mount. The `($readlink -m ...)` part will make provided path absolute, so use it if necessary
 # WARNING: don't store datasets in the same folder as dockerfile, to avoid long context loading during docker build
-export DATASETS_ROOT=/localdisk/ekrivov/datasets
+export DATASETS_ROOT=$(readlink -m $DATASETS_ROOT)
 export RESULTS_DIR=$(readlink -m results)
 
 # Archive omniscripts for the upload 


### PR DESCRIPTION
Now `DATASETS_ROOT` needs to be provided before running `all.py`, or user have to edit `all.py` beforehand. The first line in `all.sh` is responsible for that, since it sets `-u` flag and `DATASETS_ROOT` is used in the script without exporting it first.