### PR TITLE
Docker benchmark reproduction now generates xlsx and take median of 3 iterations

### DIFF
--- a/docker/e2e-hdk/Dockerfile
+++ b/docker/e2e-hdk/Dockerfile
@@ -39,11 +39,13 @@ RUN wget -nv https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.
 RUN conda update -n base -c defaults conda -y && \
     conda create --name modin_hdk && \
     conda activate modin_hdk && \
-    conda install -y python=3.9 mamba psutil braceexpand scikit-learn==1.0.2 xgboost scikit-learn-intelex -c conda-forge && \
+    conda install -y python=3.9 mamba sqlalchemy==1.4 psutil braceexpand scikit-learn==1.0.2 xgboost scikit-learn-intelex -c conda-forge && \
     conda activate modin_hdk && mamba install -y modin-hdk -c conda-forge && \
-    conda clean --all --yes
+    conda clean --all --yes && \
+    pip install --no-cache-dir XlsxWriter
 
 ENV DATASETS_PWD /datasets
+ENV DB_COMMON_OPTS="-db_name /results/result_database.sqlite"
 ENV TBB_MALLOC_USE_HUGE_PAGES 1
 
 COPY run_benchmarks.sh ${HOME}

--- a/docker/e2e-hdk/Dockerfile
+++ b/docker/e2e-hdk/Dockerfile
@@ -17,7 +17,6 @@ RUN adduser --disabled-password \
 WORKDIR ${HOME}
 
 # Done with actions that require root, switching to user mode
-
 USER ${USER}
 SHELL ["/bin/bash", "--login", "-c"]
 
@@ -45,8 +44,6 @@ ENV DB_COMMON_OPTS="-db_name /results/result_database.sqlite"
 ENV TBB_MALLOC_USE_HUGE_PAGES 1
 
 ADD omniscripts.tar omniscripts
-# RUN chown -R ${USER}:${USER} omniscripts
-# RUN chmod -R 0777 omniscripts
 
 COPY run_benchmarks.sh ${HOME}
 

--- a/docker/e2e-hdk/Dockerfile
+++ b/docker/e2e-hdk/Dockerfile
@@ -16,7 +16,7 @@ RUN adduser --disabled-password \
 
 WORKDIR ${HOME}
 
-# Done with actions that require root, switching to user mode
+# Switching to user mode for conda installation
 USER ${USER}
 SHELL ["/bin/bash", "--login", "-c"]
 
@@ -40,11 +40,17 @@ RUN conda update -n base -c defaults conda -y && \
     pip install --no-cache-dir XlsxWriter
 
 ENV DATASETS_PWD /datasets
-ENV DB_COMMON_OPTS="-db_name /results/result_database.sqlite"
 ENV TBB_MALLOC_USE_HUGE_PAGES 1
 
+# change omniscripts owner
+USER root
 ADD omniscripts.tar omniscripts
-
 COPY run_benchmarks.sh ${HOME}
+RUN chown -R ${USER}:${USER} omniscripts && chown -R ${USER}:${USER} run_benchmarks.sh
+
+# Return to user
+USER ${USER}
+SHELL ["/bin/bash", "--login", "-c"]
+
 
 CMD ["bash", "run_benchmarks.sh"]

--- a/docker/e2e-hdk/Dockerfile
+++ b/docker/e2e-hdk/Dockerfile
@@ -16,10 +16,6 @@ RUN adduser --disabled-password \
 
 WORKDIR ${HOME}
 
-ADD omniscripts.tar omniscripts
-RUN chown -R ${USER}:${USER} omniscripts
-RUN chmod -R 0777 omniscripts
-
 # Done with actions that require root, switching to user mode
 
 USER ${USER}
@@ -47,6 +43,10 @@ RUN conda update -n base -c defaults conda -y && \
 ENV DATASETS_PWD /datasets
 ENV DB_COMMON_OPTS="-db_name /results/result_database.sqlite"
 ENV TBB_MALLOC_USE_HUGE_PAGES 1
+
+ADD omniscripts.tar omniscripts
+# RUN chown -R ${USER}:${USER} omniscripts
+# RUN chmod -R 0777 omniscripts
 
 COPY run_benchmarks.sh ${HOME}
 

--- a/docker/e2e-hdk/README.md
+++ b/docker/e2e-hdk/README.md
@@ -15,4 +15,3 @@ This is a folder with everything necessary to reproduce key benchmarks.
 - `load_data.sh` - script that loads datasets
 - `run_docker.sh` - script that starts docker container and automatically start running benchmarks
 - `run_benchmarks.sh` - scripts that is copied to the container to run benchmarks.
-

--- a/docker/e2e-hdk/README.md
+++ b/docker/e2e-hdk/README.md
@@ -6,12 +6,12 @@ This is a folder with everything necessary to reproduce key benchmarks.
 
 ### How to run 
 0. You need to have complete omniscripts repository before running, so clone it or download current version.
-1. Configure `DATASETS_ROOT`. This is where the datasets will be stored, so expect this filder to have 170GB of data. To do that run `export DATASETS_ROOT=**datasets path**`. 
+1. Configure `DATASETS_PATH`. This is where the datasets will be stored, so expect this filder to have 170GB of data. To do that run `export DATASETS_PATH=**datasets path**`. 
 2. *Optional.* Open `all.sh` and modify `RESULTS` variable. This is where the benchmark results will be stored. By default they are stored in the current folder.
 3. Change dir to this folder `cd omniscripts/docker/e2e-hdk`
 4. Run `./all.sh` to benchmark. Results will be stored in `RESULTS` folder (in the current folder in `results` dir by default).
 ### Files
-- `all.sh` - Main script to run everything. Before running it, change `DATASETS_ROOT` to a location where you want to store datasets (around 170GB).
+- `all.sh` - Main script to run everything. Before running it, change `DATASETS_PATH` to a location where you want to store datasets (around 170GB).
 - `load_data.sh` - script that loads datasets
 - `run_docker.sh` - script that starts docker container and automatically start running benchmarks
 - `run_benchmarks.sh` - scripts that is copied to the container to run benchmarks.

--- a/docker/e2e-hdk/README.md
+++ b/docker/e2e-hdk/README.md
@@ -6,12 +6,13 @@ This is a folder with everything necessary to reproduce key benchmarks.
 
 ### How to run 
 0. You need to have complete omniscripts repository before running, so clone it or download current version.
-1. Configure `DATASETS_PATH`. This is where the datasets will be stored, so expect this filder to have 170GB of data. To do that run `export DATASETS_PATH=**datasets path**`. 
-2. *Optional.* Open `all.sh` and modify `RESULTS` variable. This is where the benchmark results will be stored. By default they are stored in the current folder.
-3. Change dir to this folder `cd omniscripts/docker/e2e-hdk`
-4. Run `./all.sh` to benchmark. Results will be stored in `RESULTS` folder (in the current folder in `results` dir by default).
+1. *Optional.* Open `all.sh` and modify `RESULTS` variable. This is where the benchmark results will be stored. By default they are stored in the current folder.
+2. Change dir to this folder `cd omniscripts/docker/e2e-hdk`
+3. Run `./all.sh -d DATASETS_PATH [-r xlsx]` to benchmark. Results will be stored in `RESULTS` folder (in the current folder in `results` dir by default). 
+    1. `DATASETS_PATH` is where the datasets will be stored, so expect this filder to have 170GB of data. 
+    2. Optional `-r xlsx` will generate xlsx report with benchmark results.
 ### Files
-- `all.sh` - Main script to run everything. Before running it, change `DATASETS_PATH` to a location where you want to store datasets (around 170GB).
+- `all.sh` - Main script to run everything.
 - `load_data.sh` - script that loads datasets
 - `run_docker.sh` - script that starts docker container and automatically start running benchmarks
 - `run_benchmarks.sh` - scripts that is copied to the container to run benchmarks.

--- a/docker/e2e-hdk/all.sh
+++ b/docker/e2e-hdk/all.sh
@@ -9,10 +9,11 @@ export RESULTS_DIR=$(readlink -m results)
 tar -cf omniscripts.tar  --exclude=e2e-hdk ../../.
 
 # Build the image, use optional `--build-arg http_proxy=${http_proxy} --build-arg https_proxy=${https_proxy}` to configure proxy.
+echo "Building docker image"
 docker build -t modin-project/benchmarks-reproduce:latest -f ./Dockerfile .
 
 # Download data
 ./load_data.sh
 
-# Run experiments
+# Run experiments & generate xlsx
 ./run_docker.sh

--- a/docker/e2e-hdk/all.sh
+++ b/docker/e2e-hdk/all.sh
@@ -6,6 +6,7 @@
 usage() { echo "Usage: $0 -d DATASETS_PATH [-r xlsx]" 1>&2; exit 1; }
 
 REPORT=""
+DB_COMMON_OPTS=""
 while getopts ":d:r:" o; do
     case "${o}" in
         d)
@@ -14,6 +15,7 @@ while getopts ":d:r:" o; do
         r)
             REPORT=${OPTARG}
             [[ "$REPORT" == "xlsx" ]] || ( echo "Unrecognized report type, only xlsx is supported" && usage )
+            DB_COMMON_OPTS="-db_name /results/result_database.sqlite"
             ;;
         *)
             echo "Unrecognized argument ${OPTARG}"
@@ -33,11 +35,12 @@ done
 export DATASETS_PATH=$(readlink -m $DATASETS_PATH)
 export RESULTS_DIR=$(readlink -m results)
 export REPORT
+export DB_COMMON_OPTS
 
 echo "Configured parameters: DATSETS_ROOT=$DATASETS_PATH, RESULTS_DIR=$RESULTS_DIR, REPORT=$REPORT"
 
 # Archive omniscripts for the upload 
-tar --owner 1000 --group 1000 -cf omniscripts.tar  --exclude=e2e-hdk ../../.
+tar -cf omniscripts.tar  --exclude=e2e-hdk ../../.
 
 # Build the image, use optional `--build-arg http_proxy=${http_proxy} --build-arg https_proxy=${https_proxy}` to configure proxy.
 echo "Building docker image"
@@ -46,5 +49,5 @@ docker build -t modin-project/benchmarks-reproduce:latest -f ./Dockerfile .
 # Download data
 ./load_data.sh
 
-# Run experiments & generate xlsx
+# Run experiments & generate xlsx if -r xlsx was used
 ./run_docker.sh

--- a/docker/e2e-hdk/all.sh
+++ b/docker/e2e-hdk/all.sh
@@ -1,9 +1,40 @@
-#!/bin/bash -eu
+#!/bin/bash -e
+
+####################
+# Argument parsing #
+
+usage() { echo "Usage: $0 -d DATASETS_PATH [-r xlsx]" 1>&2; exit 1; }
+
+REPORT=""
+while getopts ":d:r:" o; do
+    case "${o}" in
+        d)
+            DATASETS_PATH=${OPTARG}
+            ;;
+        r)
+            REPORT=${OPTARG}
+            [[ "$REPORT" == "xlsx" ]] || ( echo "Unrecognized report type, only xlsx is supported" && usage )
+            ;;
+        *)
+            echo "Unrecognized argument ${OPTARG}"
+            usage
+            ;;
+    esac
+done
+
+[ -z "$DATASETS_PATH" ] && echo "Please, provide DATASETS_PATH" && usage
+
+#
+####################
+
 # Set location to store datasets, 
 # WARNING: paths need to be absolute, otherwise docker will not mount. The `($readlink -m ...)` part will make provided path absolute, so use it if necessary
 # WARNING: don't store datasets in the same folder as dockerfile, to avoid long context loading during docker build
-export DATASETS_ROOT=$(readlink -m $DATASETS_ROOT)
+export DATASETS_PATH=$(readlink -m $DATASETS_PATH)
 export RESULTS_DIR=$(readlink -m results)
+export REPORT
+
+echo "Configured parameters: DATSETS_ROOT=$DATASETS_PATH, RESULTS_DIR=$RESULTS_DIR, REPORT=$REPORT"
 
 # Archive omniscripts for the upload 
 tar -cf omniscripts.tar  --exclude=e2e-hdk ../../.

--- a/docker/e2e-hdk/all.sh
+++ b/docker/e2e-hdk/all.sh
@@ -37,7 +37,7 @@ export REPORT
 echo "Configured parameters: DATSETS_ROOT=$DATASETS_PATH, RESULTS_DIR=$RESULTS_DIR, REPORT=$REPORT"
 
 # Archive omniscripts for the upload 
-tar -cf omniscripts.tar  --exclude=e2e-hdk ../../.
+tar --owner 1000 --group 1000 -cf omniscripts.tar  --exclude=e2e-hdk ../../.
 
 # Build the image, use optional `--build-arg http_proxy=${http_proxy} --build-arg https_proxy=${https_proxy}` to configure proxy.
 echo "Building docker image"

--- a/docker/e2e-hdk/load_data.sh
+++ b/docker/e2e-hdk/load_data.sh
@@ -1,4 +1,11 @@
 #!/bin/bash -eu
+if [ -z ${DATASETS_ROOT+x} ]; then
+    echo "Please, set the env variable \"DATASETS_ROOT\"!";
+    exit 1
+else
+    echo "DATSETS_ROOT=$DATASETS_ROOT"
+fi
+
 mkdir -p ${DATASETS_ROOT}
 chmod 0777 ${DATASETS_ROOT}
 

--- a/docker/e2e-hdk/load_data.sh
+++ b/docker/e2e-hdk/load_data.sh
@@ -1,18 +1,18 @@
 #!/bin/bash -eu
-if [ -z ${DATASETS_ROOT+x} ]; then
-    echo "Please, set the env variable \"DATASETS_ROOT\"!";
+if [ -z ${DATASETS_PATH+x} ]; then
+    echo "Please, set the env variable \"DATASETS_PATH\"!";
     exit 1
 else
-    echo "DATSETS_ROOT=$DATASETS_ROOT"
+    echo "DATSETS_ROOT=$DATASETS_PATH"
 fi
 
-mkdir -p ${DATASETS_ROOT}
-chmod 0777 ${DATASETS_ROOT}
+mkdir -p ${DATASETS_PATH}
+chmod 0777 ${DATASETS_PATH}
 
 USER_ID="$(id -u):$(id -g)"
 
-# awsd="docker run --rm -it -e http_proxy=${http_proxy} -e https_proxy=${https_proxy} --user ${USER_ID} -v ${DATASETS_ROOT}:/datasets amazon/aws-cli s3"
-awsd="docker run --rm -it  --user ${USER_ID} -v ${DATASETS_ROOT}:/datasets amazon/aws-cli s3"
+# awsd="docker run --rm -it -e http_proxy=${http_proxy} -e https_proxy=${https_proxy} --user ${USER_ID} -v ${DATASETS_PATH}:/datasets amazon/aws-cli s3"
+awsd="docker run --rm -it  --user ${USER_ID} -v ${DATASETS_PATH}:/datasets amazon/aws-cli s3"
 
 $awsd sync s3://modin-datasets/taxi /datasets/taxi --no-sign-request --exclude "*" --include "trips_xa[abcdefghijklmnopqrst].csv"
 $awsd sync s3://modin-datasets/plasticc /datasets/plasticc --no-sign-request --exclude "*" --include "*.csv"

--- a/docker/e2e-hdk/run_benchmarks.sh
+++ b/docker/e2e-hdk/run_benchmarks.sh
@@ -1,25 +1,32 @@
 #!/bin/bash -eu
 cd omniscripts
 
+export ADDITIONAL_OPTS="-iterations 3"
+
 # Modin_on_hdk
-export LD_PRELOAD_OLD=${LD_PRELOAD}
-export LD_LIBRARY_PATH_OLD=${LD_LIBRARY_PATH}
+# !!!This optimization is currently broken!!!
+# export LD_PRELOAD_OLD=${LD_PRELOAD}
+# export LD_LIBRARY_PATH_OLD=${LD_LIBRARY_PATH}
 
-export LD_PRELOAD=${CONDA_PREFIX}/envs/${ENV_NAME}/lib/libtbbmalloc_proxy.so.2
-export LD_LIBRARY_PATH=${CONDA_PREFIX}/envs/${ENV_NAME}/lib/
-
+# export LD_PRELOAD=${CONDA_PREFIX}/envs/${ENV_NAME}/lib/libtbbmalloc_proxy.so.2
+# export LD_LIBRARY_PATH=${CONDA_PREFIX}/envs/${ENV_NAME}/lib/
 
 ./teamcity_build_scripts/33-ny_taxi_modin_on_hdk_20M_records.sh |& tee /results/taxi_hdk.res
 ./teamcity_build_scripts/30-census_modin_on_hdk.sh |& tee /results/census_hdk.res
 ./teamcity_build_scripts/34-plasticc_modin_on_hdk.sh |& tee /results/plasticc_hdk.res
 
-export LD_PRELOAD=${LD_PRELOAD_OLD}
-export LD_LIBRARY_PATH=${LD_LIBRARY_PATH_OLD}
+# export LD_PRELOAD=${LD_PRELOAD_OLD}
+# export LD_LIBRARY_PATH=${LD_LIBRARY_PATH_OLD}
 
-#Stock pandas
+# Stock pandas
 # HDK scripts deactivate conda, so we need to reactivate it again
 source ${CONDA_PREFIX}/bin/activate
-
 ./teamcity_build_scripts/42-ny_taxi_pandas_20M_records.sh |& tee /results/taxi_pandas.res
 ./teamcity_build_scripts/41-census_pandas.sh |& tee /results/census_pandas.res
 ./teamcity_build_scripts/43-plasticc_pandas.sh |& tee /results/plasticc_pandas.res
+
+# HDK scripts deactivate conda, so we need to reactivate it again
+
+# We need to activate env to have all the libraries for report generation
+source ${CONDA_PREFIX}/bin/activate ${ENV_NAME}
+PYTHONPATH=./ python3 ./scripts/generate_report.py -report_path /results/report.xlsx -db_name /results/result_database.sqlite -agg median

--- a/docker/e2e-hdk/run_benchmarks.sh
+++ b/docker/e2e-hdk/run_benchmarks.sh
@@ -5,18 +5,18 @@ export ADDITIONAL_OPTS="-iterations 3"
 
 # Modin_on_hdk
 # !!!This optimization is currently broken!!!
-# export LD_PRELOAD_OLD=${LD_PRELOAD}
-# export LD_LIBRARY_PATH_OLD=${LD_LIBRARY_PATH}
+export LD_PRELOAD_OLD=${LD_PRELOAD}
+export LD_LIBRARY_PATH_OLD=${LD_LIBRARY_PATH}
 
-# export LD_PRELOAD=${CONDA_PREFIX}/envs/${ENV_NAME}/lib/libtbbmalloc_proxy.so.2
-# export LD_LIBRARY_PATH=${CONDA_PREFIX}/envs/${ENV_NAME}/lib/
+export LD_PRELOAD=${CONDA_PREFIX}/envs/${ENV_NAME}/lib/libtbbmalloc_proxy.so.2
+export LD_LIBRARY_PATH=${CONDA_PREFIX}/envs/${ENV_NAME}/lib/
 
 ./teamcity_build_scripts/33-ny_taxi_modin_on_hdk_20M_records.sh |& tee /results/taxi_hdk.res
 ./teamcity_build_scripts/30-census_modin_on_hdk.sh |& tee /results/census_hdk.res
 ./teamcity_build_scripts/34-plasticc_modin_on_hdk.sh |& tee /results/plasticc_hdk.res
 
-# export LD_PRELOAD=${LD_PRELOAD_OLD}
-# export LD_LIBRARY_PATH=${LD_LIBRARY_PATH_OLD}
+export LD_PRELOAD=${LD_PRELOAD_OLD}
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH_OLD}
 
 # Stock pandas
 # HDK scripts deactivate conda, so we need to reactivate it again

--- a/docker/e2e-hdk/run_benchmarks.sh
+++ b/docker/e2e-hdk/run_benchmarks.sh
@@ -1,22 +1,13 @@
 #!/bin/bash -eu
 cd omniscripts
 
-export ADDITIONAL_OPTS="-iterations 3"
+export ADDITIONAL_OPTS="-iterations 1"
 
 # Modin_on_hdk
-# !!!This optimization is currently broken!!!
-export LD_PRELOAD_OLD=${LD_PRELOAD}
-export LD_LIBRARY_PATH_OLD=${LD_LIBRARY_PATH}
-
-export LD_PRELOAD=${CONDA_PREFIX}/envs/${ENV_NAME}/lib/libtbbmalloc_proxy.so.2
-export LD_LIBRARY_PATH=${CONDA_PREFIX}/envs/${ENV_NAME}/lib/
 
 ./teamcity_build_scripts/33-ny_taxi_modin_on_hdk_20M_records.sh |& tee /results/taxi_hdk.res
 ./teamcity_build_scripts/30-census_modin_on_hdk.sh |& tee /results/census_hdk.res
 ./teamcity_build_scripts/34-plasticc_modin_on_hdk.sh |& tee /results/plasticc_hdk.res
-
-export LD_PRELOAD=${LD_PRELOAD_OLD}
-export LD_LIBRARY_PATH=${LD_LIBRARY_PATH_OLD}
 
 # Stock pandas
 # HDK scripts deactivate conda, so we need to reactivate it again

--- a/docker/e2e-hdk/run_benchmarks.sh
+++ b/docker/e2e-hdk/run_benchmarks.sh
@@ -15,18 +15,16 @@ source ${CONDA_PREFIX}/bin/activate
 ./teamcity_build_scripts/41-census_pandas.sh |& tee /results/census_pandas.res
 ./teamcity_build_scripts/43-plasticc_pandas.sh |& tee /results/plasticc_pandas.res
 
-# HDK scripts deactivate conda, so we need to reactivate it again
-
 case $REPORT in
 
   xlsx)
-    echo -n "Generating xlsx report"
+    echo "Generating xlsx report..."
     # We need to activate env to have all the libraries for report generation
     source ${CONDA_PREFIX}/bin/activate ${ENV_NAME}
     PYTHONPATH=./ python3 ./scripts/generate_report.py -report_path /results/report.xlsx -db_name /results/result_database.sqlite -agg median
     ;;
 
   *)
-    echo -n "No report generation"
+    echo "No report generation"
     ;;
 esac

--- a/docker/e2e-hdk/run_benchmarks.sh
+++ b/docker/e2e-hdk/run_benchmarks.sh
@@ -1,10 +1,9 @@
-#!/bin/bash -eu
+#!/bin/bash -e
 cd omniscripts
 
-export ADDITIONAL_OPTS="-iterations 1"
+export ADDITIONAL_OPTS="-iterations 3"
 
 # Modin_on_hdk
-
 ./teamcity_build_scripts/33-ny_taxi_modin_on_hdk_20M_records.sh |& tee /results/taxi_hdk.res
 ./teamcity_build_scripts/30-census_modin_on_hdk.sh |& tee /results/census_hdk.res
 ./teamcity_build_scripts/34-plasticc_modin_on_hdk.sh |& tee /results/plasticc_hdk.res
@@ -18,6 +17,16 @@ source ${CONDA_PREFIX}/bin/activate
 
 # HDK scripts deactivate conda, so we need to reactivate it again
 
-# We need to activate env to have all the libraries for report generation
-source ${CONDA_PREFIX}/bin/activate ${ENV_NAME}
-PYTHONPATH=./ python3 ./scripts/generate_report.py -report_path /results/report.xlsx -db_name /results/result_database.sqlite -agg median
+case $REPORT in
+
+  xlsx)
+    echo -n "Generating xlsx report"
+    # We need to activate env to have all the libraries for report generation
+    source ${CONDA_PREFIX}/bin/activate ${ENV_NAME}
+    PYTHONPATH=./ python3 ./scripts/generate_report.py -report_path /results/report.xlsx -db_name /results/result_database.sqlite -agg median
+    ;;
+
+  *)
+    echo -n "No report generation"
+    ;;
+esac

--- a/docker/e2e-hdk/run_benchmarks.sh
+++ b/docker/e2e-hdk/run_benchmarks.sh
@@ -21,7 +21,7 @@ case $REPORT in
     echo "Generating xlsx report..."
     # We need to activate env to have all the libraries for report generation
     source ${CONDA_PREFIX}/bin/activate ${ENV_NAME}
-    PYTHONPATH=./ python3 ./scripts/generate_report.py -report_path /results/report.xlsx -db_name /results/result_database.sqlite -agg median
+    PYTHONPATH=./ python3 ./scripts/generate_report.py -report_path /results/report.xlsx $DB_COMMON_OPTS -agg median
     ;;
 
   *)

--- a/docker/e2e-hdk/run_docker.sh
+++ b/docker/e2e-hdk/run_docker.sh
@@ -1,4 +1,11 @@
 #!/bin/bash -eu
+if [ -z ${DATASETS_ROOT+x} ]; then
+    echo "Please, set the env variable \"DATASETS_ROOT\"!";
+    exit 1
+else
+    echo "DATSETS_ROOT=$DATASETS_ROOT"
+fi
+
 mkdir -p ${RESULTS_DIR}
 chmod 0777 ${RESULTS_DIR}
 

--- a/docker/e2e-hdk/run_docker.sh
+++ b/docker/e2e-hdk/run_docker.sh
@@ -1,9 +1,9 @@
 #!/bin/bash -eu
-if [ -z ${DATASETS_ROOT+x} ]; then
-    echo "Please, set the env variable \"DATASETS_ROOT\"!";
+if [ -z ${DATASETS_PATH+x} ]; then
+    echo "Please, set the env variable \"DATASETS_PATH\"!";
     exit 1
 else
-    echo "DATSETS_ROOT=$DATASETS_ROOT"
+    echo "DATSETS_ROOT=$DATASETS_PATH"
 fi
 
 mkdir -p ${RESULTS_DIR}
@@ -13,7 +13,7 @@ USER_ID="$(id -u):$(id -g)"
 
 docker run \
   -it \
-  -v ${DATASETS_ROOT}:/datasets:ro  \
+  -v ${DATASETS_PATH}:/datasets:ro  \
   -v ${RESULTS_DIR}:/results \
   --user ${USER_ID} \
   modin-project/benchmarks-reproduce:latest 

--- a/docker/e2e-hdk/run_docker.sh
+++ b/docker/e2e-hdk/run_docker.sh
@@ -16,4 +16,5 @@ docker run \
   -v ${DATASETS_PATH}:/datasets:ro  \
   -v ${RESULTS_DIR}:/results \
   --user ${USER_ID} \
+  --env REPORT=$REPORT \
   modin-project/benchmarks-reproduce:latest 

--- a/docker/e2e-hdk/run_docker.sh
+++ b/docker/e2e-hdk/run_docker.sh
@@ -16,5 +16,6 @@ docker run \
   -v ${DATASETS_PATH}:/datasets:ro  \
   -v ${RESULTS_DIR}:/results \
   --user ${USER_ID} \
-  --env REPORT=$REPORT \
+  --env REPORT="${REPORT}" \
+  --env DB_COMMON_OPTS="${DB_COMMON_OPTS}" \
   modin-project/benchmarks-reproduce:latest 


### PR DESCRIPTION
This PR updates docker folder with reproduction of selected benchmarks, adding xlsx generation based on benchmark results. It depends on https://github.com/intel-ai/omniscripts/pull/337