### PR TITLE
Benchmarks now support unique arguments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,4 +34,4 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install .
-          PANDAS_MODE="Pandas" benchmark-run -b example_benchmark -data_file "/datasets"
+          PANDAS_MODE="Pandas" benchmark-run example_benchmark -data_file "/datasets"

--- a/build_scripts/00-run_bench.sh
+++ b/build_scripts/00-run_bench.sh
@@ -16,6 +16,8 @@ else
 fi
 
 # Run benchmark
+# ENV_NAME must be provided
+# live stream will provide live stdout and stderr
 conda run --live-stream -n $ENV_NAME benchmark-run $BENCH_NAME    \
                            -data_file "${DATA_FILE}"              \
                            -pandas_mode ${PANDAS_MODE}            \

--- a/build_scripts/00-run_bench.sh
+++ b/build_scripts/00-run_bench.sh
@@ -16,6 +16,7 @@ else
 fi
 
 # Run benchmark
+
 # ENV_NAME must be provided
 # live stream will provide live stdout and stderr
 conda run --live-stream -n $ENV_NAME benchmark-run $BENCH_NAME    \

--- a/build_scripts/00-run_bench.sh
+++ b/build_scripts/00-run_bench.sh
@@ -19,8 +19,16 @@ fi
 
 # ENV_NAME must be provided
 # live stream will provide live stdout and stderr
-conda run --live-stream -n $ENV_NAME python3 run_modin_tests.py   \
-                           -bench_name $BENCH_NAME                \
+# conda run --live-stream -n $ENV_NAME python3 run_modin_tests.py   \
+#                            -bench_name $BENCH_NAME                \
+#                            -data_file "${DATA_FILE}"              \
+#                            -pandas_mode ${PANDAS_MODE}            \
+#                            -ray_tmpdir ${PWD}/tmp                 \
+#                            ${ADDITIONAL_OPTS}                     \
+#                            ${DB_COMMON_OPTS}                      \
+#                            "$@"
+
+conda run --live-stream -n $ENV_NAME benchmark-run $BENCH_NAME    \
                            -data_file "${DATA_FILE}"              \
                            -pandas_mode ${PANDAS_MODE}            \
                            -ray_tmpdir ${PWD}/tmp                 \

--- a/build_scripts/00-run_bench.sh
+++ b/build_scripts/00-run_bench.sh
@@ -16,18 +16,6 @@ else
 fi
 
 # Run benchmark
-
-# ENV_NAME must be provided
-# live stream will provide live stdout and stderr
-# conda run --live-stream -n $ENV_NAME python3 run_modin_tests.py   \
-#                            -bench_name $BENCH_NAME                \
-#                            -data_file "${DATA_FILE}"              \
-#                            -pandas_mode ${PANDAS_MODE}            \
-#                            -ray_tmpdir ${PWD}/tmp                 \
-#                            ${ADDITIONAL_OPTS}                     \
-#                            ${DB_COMMON_OPTS}                      \
-#                            "$@"
-
 conda run --live-stream -n $ENV_NAME benchmark-run $BENCH_NAME    \
                            -data_file "${DATA_FILE}"              \
                            -pandas_mode ${PANDAS_MODE}            \

--- a/build_scripts/ny_taxi_ml.sh
+++ b/build_scripts/ny_taxi_ml.sh
@@ -4,9 +4,9 @@ BENCH_NAME="ny_taxi_ml"
 DATA_FILE="${DATASETS_PWD}/yellow-taxi-dataset/"
 
 if [ "$PANDAS_MODE" = "Modin_on_ray" ]; then
-    USE_MODIN_XGB="True"
+    USE_MODIN_XGB="-use_modin_xgb"
 else
-    USE_MODIN_XGB="False"
+    USE_MODIN_XGB=""
 fi
 
-source $(dirname "$0")/00-run_bench.sh -use_modin_xgb "${USE_MODIN_XGB}"
+source $(dirname "$0")/00-run_bench.sh "${USE_MODIN_XGB}"

--- a/build_scripts/plasticc.sh
+++ b/build_scripts/plasticc.sh
@@ -7,6 +7,6 @@ export MODIN_HDK_FRAGMENT_SIZE=32000000
 BENCH_NAME="plasticc"
 DATA_FILE="${DATASETS_PWD}/plasticc/"
 
-# This benchmark also support -use_xgb True
-USE_MODIN_XGB="False"
-source $(dirname "$0")/00-run_bench.sh -use_modin_xgb "${USE_MODIN_XGB}"
+# This benchmark also support USE_MODIN_XGB="-use_modin_xgb"
+USE_MODIN_XGB=""
+source $(dirname "$0")/00-run_bench.sh "${USE_MODIN_XGB}"

--- a/omniscripts/__init__.py
+++ b/omniscripts/__init__.py
@@ -1,4 +1,4 @@
-from .benchmark import BaseBenchmark, BenchmarkResults, run_benchmarks
+from .benchmark import BaseBenchmark, BenchmarkResults
 from .timer import TimerManager
 from . import benchmark_utils
 from . import scripts

--- a/omniscripts/arg_parser.py
+++ b/omniscripts/arg_parser.py
@@ -1,12 +1,11 @@
 """Argument parsing"""
 import argparse
 from dataclasses import dataclass
-from typing import Union
 
 from .pandas_backend import Backend
 
 
-__all__ = ["add_sql_arguments", "prepare_parser", "DbConfig"]
+__all__ = ["add_sql_arguments", "prepare_general_parser", "parse_args", "DbConfig"]
 
 
 # This can be written as just a function, but we keep the dataclass to add validation and arg parsing in the future.
@@ -40,17 +39,6 @@ class DbConfig:
         return create_engine(url)
 
 
-def str_arg_to_bool(v: Union[bool, str]) -> bool:
-    if isinstance(v, bool):
-        return v
-    if v.lower() in ("yes", "true", "t", "y", "1"):
-        return True
-    elif v.lower() in ("no", "false", "f", "n", "0"):
-        return False
-    else:
-        raise argparse.ArgumentTypeError("Cannot recognize boolean value.")
-
-
 def add_sql_arguments(parser):
     parser.add_argument(
         "-db_driver",
@@ -79,7 +67,7 @@ def add_sql_arguments(parser):
     )
 
 
-def prepare_parser():
+def prepare_general_parser():
     parser = argparse.ArgumentParser(description="Run benchmarks for Modin perf testing")
     optional = parser.add_argument_group("optional arguments")
     benchmark = parser.add_argument_group("benchmark")
@@ -87,9 +75,9 @@ def prepare_parser():
     commits = parser.add_argument_group("commits")
 
     # Benchmark parameters
-    benchmark.add_argument("-bench_name", dest="bench_name", help="Benchmark name.")
+    benchmark.add_argument("bench_name", help="Benchmark name.")
     benchmark.add_argument(
-        "-data_file", dest="data_file", help="A datafile that should be loaded."
+        "-data_file", dest="data_file", help="A datafile that should be loaded.", required=True
     )
     benchmark.add_argument(
         "-dfiles_num",
@@ -104,13 +92,6 @@ def prepare_parser():
         default=1,
         type=int,
         help="Number of iterations to run. All results will be submitted to the DB.",
-    )
-    benchmark.add_argument(
-        "-validation",
-        dest="validation",
-        default=False,
-        type=str_arg_to_bool,
-        help="validate queries results (by comparison with Pandas queries results).",
     )
     benchmark.add_argument(
         "-optimizer",
@@ -128,7 +109,7 @@ def prepare_parser():
     )
     benchmark.add_argument(
         "-ray_tmpdir",
-        default="/tmp",
+        default="f/tmp",
         help="Location where to keep Ray plasma store. "
         "It should have enough space to keep -ray_memory",
     )
@@ -140,14 +121,14 @@ def prepare_parser():
     )
     benchmark.add_argument(
         "-no_ml",
-        default=None,
-        type=str_arg_to_bool,
+        default=False,
+        action="store_true",
         help="Do not run machine learning benchmark, only ETL part",
     )
     benchmark.add_argument(
         "-use_modin_xgb",
         default=False,
-        type=str_arg_to_bool,
+        action="store_true",
         help="Whether to use Modin XGBoost for ML part, relevant for Plasticc benchmark only",
     )
     optional.add_argument(
@@ -162,7 +143,7 @@ def prepare_parser():
         "-extended_functionality",
         dest="extended_functionality",
         default=False,
-        type=str_arg_to_bool,
+        action="store_true",
         help="Extends functionality of H2O benchmark by adding 'chk' functions and verbose local reporting of results",
     )
     # SQL database parameters
@@ -186,4 +167,22 @@ def prepare_parser():
         default="1234567890123456789012345678901234567890",
         help="Modin commit hash used for tests.",
     )
+
     return parser
+
+
+def parse_args(add_benchmark_args):
+    parser = prepare_general_parser()
+    benchmark_parser = parser.add_argument_group("benchmark_specific")
+    add_benchmark_args(benchmark_parser)
+    args = parser.parse_args()
+
+    db_config = DbConfig(
+        driver=args.db_driver,
+        server=args.db_server,
+        port=args.db_port,
+        user=args.db_user,
+        password=args.db_pass,
+        name=args.db_name,
+    )
+    return args, db_config

--- a/omniscripts/arg_parser.py
+++ b/omniscripts/arg_parser.py
@@ -1,6 +1,7 @@
 """Argument parsing"""
 import argparse
 from dataclasses import dataclass
+from typing import Callable
 
 from .pandas_backend import Backend
 
@@ -167,11 +168,12 @@ def prepare_general_parser():
         default="1234567890123456789012345678901234567890",
         help="Modin commit hash used for tests.",
     )
-
     return parser
 
 
-def parse_args(add_benchmark_args):
+def parse_args(add_benchmark_args: Callable[[argparse.ArgumentParser], None]):
+    """Parse arguments including benchmark-specific arguments that will be added using provided 
+    `add_benchmark_args` callable"""
     parser = prepare_general_parser()
     benchmark_parser = parser.add_argument_group("benchmark_specific")
     add_benchmark_args(benchmark_parser)
@@ -185,4 +187,5 @@ def parse_args(add_benchmark_args):
         password=args.db_pass,
         name=args.db_name,
     )
+
     return args, db_config

--- a/omniscripts/arg_parser.py
+++ b/omniscripts/arg_parser.py
@@ -109,7 +109,7 @@ def prepare_general_parser():
     )
     benchmark.add_argument(
         "-ray_tmpdir",
-        default="f/tmp",
+        default="/tmp",
         help="Location where to keep Ray plasma store. "
         "It should have enough space to keep -ray_memory",
     )

--- a/omniscripts/arg_parser.py
+++ b/omniscripts/arg_parser.py
@@ -172,7 +172,7 @@ def prepare_general_parser():
 
 
 def parse_args(add_benchmark_args: Callable[[argparse.ArgumentParser], None]):
-    """Parse arguments including benchmark-specific arguments that will be added using provided 
+    """Parse arguments including benchmark-specific arguments that will be added using provided
     `add_benchmark_args` callable"""
     parser = prepare_general_parser()
     benchmark_parser = parser.add_argument_group("benchmark_specific")

--- a/omniscripts/benchmark.py
+++ b/omniscripts/benchmark.py
@@ -1,12 +1,7 @@
 import abc
-import time
+import argparse
 import warnings
 from typing import Dict
-
-from .pandas_backend import Backend
-
-from .arg_parser import DbConfig
-from .benchmarks import create_benchmark
 
 
 class BenchmarkResults:
@@ -49,6 +44,13 @@ class BenchmarkResults:
 class BaseBenchmark(abc.ABC):
     # Unsupported running parameters to warn user about
     __unsupported_params__ = tuple()
+    # Tuple with parameters, specific for this benchmark
+    __params__ = tuple()
+
+    def add_benchmark_args(self, parser: argparse.ArgumentParser):
+        """Benchmark can add arguments for parsing and they will be available in `params`
+        during the run"""
+        pass
 
     def prerun(self, params):
         self.check_support(params)
@@ -75,112 +77,3 @@ class BaseBenchmark(abc.ABC):
     @abc.abstractmethod
     def run_benchmark(self, params) -> BenchmarkResults:
         pass
-
-
-def run_benchmarks(
-    bench_name: str,
-    data_file: str,
-    dfiles_num: int = None,
-    iterations: int = 1,
-    validation: bool = False,
-    optimizer: str = None,
-    pandas_mode: str = "Pandas",
-    ray_tmpdir: str = "/tmp",
-    ray_memory: int = 200 * 1024 * 1024 * 1024,
-    no_ml: bool = None,
-    use_modin_xgb: bool = False,
-    gpu_memory: int = None,
-    extended_functionality: bool = False,
-    db_config: DbConfig = None,
-    commit_hdk: str = "1234567890123456789012345678901234567890",
-    commit_omniscripts: str = "1234567890123456789012345678901234567890",
-    commit_modin: str = "1234567890123456789012345678901234567890",
-):
-    """
-    Run benchmarks for Modin perf testing and report results.
-
-    Parameters
-    ----------
-    bench_name : str
-        Benchmark name.
-    data_file : str
-        A datafile that should be loaded.
-    dfiles_num : int, optional
-        Number of datafiles to load into database for processing.
-    iterations : int, default: 1
-        Number of iterations to run every query. The best result is selected.
-    validation : bool, default: False
-        Validate queries results (by comparison with Pandas queries results).
-    optimizer : str, optional
-        Optimizer to use.
-    pandas_mode : str, default: "Pandas"
-        Specifies which version of Pandas to use: plain Pandas, Modin runing on Ray or on Dask or on HDK.
-    ray_tmpdir : str, default: "/tmp"
-        Location where to keep Ray plasma store. It should have enough space to keep `ray_memory`.
-    ray_memory : int, default: 200 * 1024 * 1024 * 1024
-        Size of memory to allocate for Ray plasma store.
-    no_ml : bool, optional
-        Do not run machine learning benchmark, only ETL part.
-    use_modin_xgb : bool, default: False
-        Whether to use Modin XGBoost for ML part, relevant for Plasticc benchmark only.
-    gpu_memory : int, optional
-        Specify the memory of your gpu(This controls the lines to be used. Also work for CPU version).
-    extended_functionality : bool, default: False
-        Extends functionality of H2O benchmark by adding 'chk' functions and verbose local reporting of results.
-    db_config: DbConfig, optional
-        Configuration for the database
-    commit_hdk : str, default: "1234567890123456789012345678901234567890"
-        HDK commit hash used for benchmark.
-    commit_omniscripts : str, default: "1234567890123456789012345678901234567890"
-        Omniscripts commit hash used for benchmark.
-    commit_modin : str, default: "1234567890123456789012345678901234567890"
-        Modin commit hash used for benchmark.
-    """
-
-    data_file = data_file.replace("'", "")
-
-    # Set current backend, !!!needs to be run before benchmark import!!!
-    Backend.init(backend_name=pandas_mode, ray_tmpdir=ray_tmpdir, ray_memory=ray_memory)
-
-    benchmark: BaseBenchmark = create_benchmark(bench_name)
-
-    run_parameters = {
-        "data_file": data_file,
-        "dfiles_num": dfiles_num,
-        "no_ml": no_ml,
-        "use_modin_xgb": use_modin_xgb,
-        "optimizer": optimizer,
-        "pandas_mode": pandas_mode,
-        "ray_tmpdir": ray_tmpdir,
-        "ray_memory": ray_memory,
-        "gpu_memory": gpu_memory,
-        "validation": validation,
-        "extended_functionality": extended_functionality,
-        "commit_hdk": commit_hdk,
-        "commit_omniscripts": commit_omniscripts,
-        "commit_modin": commit_modin,
-    }
-
-    run_id = int(round(time.time()))
-    print(run_parameters)
-
-    if db_config is not None:
-        from .report import BenchmarkDb
-
-        reporter = BenchmarkDb(db_config.create_engine())
-    else:
-        reporter = None
-
-    for iter_num in range(1, iterations + 1):
-        print(f"Iteration #{iter_num}")
-        results: BenchmarkResults = benchmark.run(run_parameters)
-
-        if reporter is not None:
-            reporter.report(
-                iteration_no=iter_num,
-                name2time=results.measurements,
-                params=results.params,
-                benchmark=bench_name,
-                run_id=run_id,
-                run_params=run_parameters,
-            )

--- a/omniscripts/benchmarks/ny_taxi/taxibench_pandas_modin.py
+++ b/omniscripts/benchmarks/ny_taxi/taxibench_pandas_modin.py
@@ -1,4 +1,5 @@
 # Original SQL queries can be found here https://tech.marksblogg.com/billion-nyc-taxi-rides-nvidia-pascal-titan-x-mapd.html
+import argparse
 from collections import OrderedDict
 from timeit import default_timer as timer
 
@@ -378,6 +379,16 @@ def run_benchmark(parameters):
 
 class Benchmark(BaseBenchmark):
     __unsupported_params__ = ("optimizer", "no_ml", "gpu_memory")
+    __parms__ = ("validation",)
+
+    def add_benchmark_args(self, parser: argparse.ArgumentParser):
+        parser.add_argument(
+            "-validation",
+            dest="validation",
+            default=False,
+            action="store_true",
+            help="validate queries results (by comparison with Pandas queries results).",
+        )
 
     def run_benchmark(self, params) -> BenchmarkResults:
         return run_benchmark(params)

--- a/omniscripts/benchmarks/ny_taxi/taxibench_pandas_modin.py
+++ b/omniscripts/benchmarks/ny_taxi/taxibench_pandas_modin.py
@@ -379,7 +379,7 @@ def run_benchmark(parameters):
 
 class Benchmark(BaseBenchmark):
     __unsupported_params__ = ("optimizer", "no_ml", "gpu_memory")
-    __parms__ = ("validation",)
+    __params__ = ("validation",)
 
     def add_benchmark_args(self, parser: argparse.ArgumentParser):
         parser.add_argument(

--- a/omniscripts/scripts/benchmark_run.py
+++ b/omniscripts/scripts/benchmark_run.py
@@ -1,49 +1,86 @@
 import os
+import time
 
-from omniscripts import run_benchmarks
-from omniscripts.arg_parser import DbConfig, prepare_parser
+from omniscripts.arg_parser import parse_args, prepare_general_parser
+from omniscripts.benchmark import BaseBenchmark
+from omniscripts.benchmarks import create_benchmark
+from omniscripts.pandas_backend import Backend
 
 
-def main(raw_args=None):
+def make_benchmark() -> BaseBenchmark:
+    """Function imports and creates benchmark object without using benchmark-specific arguments"""
+    parser = prepare_general_parser()
+    args = parser.parse_known_args()[0]
+    bench_name = args.bench_name
+
+    # Set current backend, !!!needs to be run before benchmark import!!!
+    Backend.init(
+        backend_name=args.pandas_mode, ray_tmpdir=args.ray_tmpdir, ray_memory=args.ray_memory
+    )
+
+    return create_benchmark(bench_name)
+
+
+def main():
     os.environ["PYTHONIOENCODING"] = "UTF-8"
     os.environ["PYTHONUNBUFFERED"] = "1"
 
-    parser = prepare_parser()
-    args = parser.parse_args(raw_args)
+    benchmark = make_benchmark()
+    args, db_config = parse_args(benchmark.add_benchmark_args)
 
-    if not args.data_file:
-        raise ValueError(
-            "Parameter --data_file was received empty, but it is required for benchmarks"
-        )
+    data_file = args.data_file.replace("'", "")
 
-    db_config = DbConfig(
-        driver=args.db_driver,
-        server=args.db_server,
-        port=args.db_port,
-        user=args.db_user,
-        password=args.db_pass,
-        name=args.db_name,
-    )
+    run_parameters = {
+        "data_file": data_file,
+        "pandas_mode": args.pandas_mode,
+        "no_ml": args.no_ml,
+        # used only in ny_taxi
+        "dfiles_num": args.dfiles_num,
+        # Used in ny_taxi_ml and plasticc
+        "use_modin_xgb": args.use_modin_xgb,
+        # Used only for census
+        "optimizer": args.optimizer,
+        # Used only for census
+        "gpu_memory": args.gpu_memory,
+        # Used only in ny_taxi
+        "validation": args.validation,
+        # Used only for old H2O
+        "extended_functionality": args.extended_functionality,
+        # Add benchmark-specific arguments
+        **{k: getattr(args, k) for k in benchmark.__params__},
+    }
 
-    run_benchmarks(
-        args.bench_name,
-        args.data_file,
-        args.dfiles_num,
-        args.iterations,
-        args.validation,
-        args.optimizer,
-        args.pandas_mode,
-        args.ray_tmpdir,
-        args.ray_memory,
-        args.no_ml,
-        args.use_modin_xgb,
-        args.gpu_memory,
-        args.extended_functionality,
-        db_config,
-        args.commit_hdk,
-        args.commit_omniscripts,
-        args.commit_modin,
-    )
+    report_args = {
+        "ray_tmpdir": args.ray_tmpdir,
+        "ray_memory": args.ray_memory,
+        "commit_hdk": args.commit_hdk,
+        "commit_omniscripts": args.commit_omniscripts,
+        "commit_modin": args.commit_modin,
+    }
+
+    if db_config is not None:
+        from ..report import BenchmarkDb
+
+        reporter = BenchmarkDb(db_config.create_engine())
+    else:
+        reporter = None
+
+    run_id = int(round(time.time()))
+    print(run_parameters)
+
+    for iter_num in range(1, args.iterations + 1):
+        print(f"Iteration #{iter_num}")
+        results = benchmark.run(run_parameters)
+
+        if reporter is not None:
+            reporter.report(
+                iteration_no=iter_num,
+                name2time=results.measurements,
+                params=results.params,
+                benchmark=args.bench_name,
+                run_id=run_id,
+                run_params={**run_parameters, **report_args},
+            )
 
 
 if __name__ == "__main__":

--- a/omniscripts/scripts/benchmark_run.py
+++ b/omniscripts/scripts/benchmark_run.py
@@ -21,6 +21,12 @@ def make_benchmark() -> BaseBenchmark:
     return create_benchmark(bench_name)
 
 
+def legacy_patch(run_parameters):
+    # We patch run_parameters because database expects all params, including benchmark-specific
+    # TODO: Legacy fix, to be removed after database migration to reflect benchmark-specific fields
+    run_parameters["validation"] = run_parameters.get("validation", "False")
+
+
 def main():
     os.environ["PYTHONIOENCODING"] = "UTF-8"
     os.environ["PYTHONUNBUFFERED"] = "1"
@@ -47,6 +53,8 @@ def main():
         # Add benchmark-specific arguments
         **{k: getattr(args, k) for k in benchmark.__params__},
     }
+
+    legacy_patch(run_parameters)
 
     report_args = {
         "ray_tmpdir": args.ray_tmpdir,

--- a/omniscripts/scripts/benchmark_run.py
+++ b/omniscripts/scripts/benchmark_run.py
@@ -42,8 +42,6 @@ def main():
         "optimizer": args.optimizer,
         # Used only for census
         "gpu_memory": args.gpu_memory,
-        # Used only in ny_taxi
-        "validation": args.validation,
         # Used only for old H2O
         "extended_functionality": args.extended_functionality,
         # Add benchmark-specific arguments


### PR DESCRIPTION
With this patch Benchmark classes can define their own parser parts, that will read arguments, specific to them. So, for instance `ny_taxi` can define and read it's own arguments. This patch contains example usage with `ny_taxi` benchmark.

Closes https://github.com/intel-ai/omniscripts/issues/418