### PR TITLE
ASV: remove `export MODIN_EXPERIMENTAL=true` from `asv-runner.sh`

### DIFF
--- a/docker/microbenchmarks-hdk/asv-runner.sh
+++ b/docker/microbenchmarks-hdk/asv-runner.sh
@@ -2,7 +2,6 @@
 eval source ${CONDA_PREFIX}/bin/activate ${ENV_NAME}
 
 # Basic config
-export MODIN_EXPERIMENTAL=true
 export MODIN_TEST_DATASET_SIZE=big
 export MODIN_ASV_DATASIZE_CONFIG=`pwd`/omniscripts/docker/microbenchmarks-hdk/modin-asv-datasize-config.json
 


### PR DESCRIPTION
Experimental mode is set automatically - details in https://github.com/modin-project/modin/pull/3670.

We also don't want to enable experimental mode for Ray.